### PR TITLE
Make RowFieldValue untyped

### DIFF
--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -534,10 +534,16 @@ pub struct RowSet {
 
 // ANCHOR: RowFieldValue
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
-#[serde(untagged)]
-pub enum RowFieldValue {
-    Relationship(RowSet),
-    Column(serde_json::Value),
+pub struct RowFieldValue(pub serde_json::Value);
+
+impl RowFieldValue {
+    /// In the case where this field value was obtained using a
+    /// [`Field::Relationship`], the returned JSON will be a [`RowSet`].
+    /// We cannot express [`RowFieldValue`] as an enum, because
+    /// [`RowFieldValue`] overlaps with values which have object types.
+    pub fn as_rowset(self) -> Option<RowSet> {
+        serde_json::from_value(self.0).ok()
+    }
 }
 // ANCHOR_END: RowFieldValue
 

--- a/ndc-client/tests/json_schema/mutation_response.jsonschema
+++ b/ndc-client/tests/json_schema/mutation_response.jsonschema
@@ -42,39 +42,6 @@
         }
       }
     },
-    "RowFieldValue": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/RowSet"
-        },
-        true
-      ]
-    },
-    "RowSet": {
-      "type": "object",
-      "properties": {
-        "aggregates": {
-          "description": "The results of the aggregates returned by the query",
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": true
-        },
-        "rows": {
-          "description": "The rows returned by the query, corresponding to the query's fields",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/definitions/RowFieldValue"
-            }
-          }
-        }
-      }
-    }
+    "RowFieldValue": true
   }
 }

--- a/ndc-client/tests/json_schema/query_response.jsonschema
+++ b/ndc-client/tests/json_schema/query_response.jsonschema
@@ -7,14 +7,7 @@
     "$ref": "#/definitions/RowSet"
   },
   "definitions": {
-    "RowFieldValue": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/RowSet"
-        },
-        true
-      ]
-    },
+    "RowFieldValue": true,
     "RowSet": {
       "type": "object",
       "properties": {

--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -1426,10 +1426,9 @@ fn eval_field(
     item: &Row,
 ) -> Result<models::RowFieldValue, StatusLine> {
     match field {
-        models::Field::Column { column, .. } => Ok(models::RowFieldValue(eval_column(
-            item,
-            column.as_str(),
-        )?)),
+        models::Field::Column { column, .. } => {
+            Ok(models::RowFieldValue(eval_column(item, column.as_str())?))
+        }
         models::Field::Relationship {
             relationship,
             arguments,
@@ -1460,9 +1459,8 @@ fn eval_field(
                 Some(root),
                 collection,
             )?;
-            let rows_json = serde_json::to_value(rows).map_err(|_| {
-                (StatusCode::INTERNAL_SERVER_ERROR, "cannot encode rowset")
-            })?;
+            let rows_json = serde_json::to_value(rows)
+                .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "cannot encode rowset"))?;
             Ok(models::RowFieldValue(rows_json))
         }
     }
@@ -1627,12 +1625,15 @@ mod tests {
 
             let mut expected = mint.new_goldenfile(expected_path).unwrap();
 
-            write!(
-                expected,
-                "{}",
-                serde_json::to_string_pretty(&response.0).unwrap()
-            )
-            .unwrap();
+            let response_json = serde_json::to_string_pretty(&response.0).unwrap();
+
+            write!(expected, "{}", response_json).unwrap();
+
+            // Test roundtrip
+            assert_eq!(
+                response.0,
+                serde_json::from_str(response_json.as_str()).unwrap()
+            );
         });
     }
 


### PR DESCRIPTION
This changes the representation of the query response to make `RowFieldValue` untyped. This makes it possible to distinguish between column and relationship fields, instead of relationship fields overlapping with object-typed column values.

Note that previously, trying to parse the output using serde would give the wrong answer for any object-typed column field, because it would be parsed as an empty relationship field instead.

This also includes a round-trip test on the responses.

Replaces #15.