### PR TITLE
Root collection should be reset at relationship boundaries

### DIFF
--- a/ndc-reference/tests/query/predicate_with_unrelated_exists_and_relationship/expected.json
+++ b/ndc-reference/tests/query/predicate_with_unrelated_exists_and_relationship/expected.json
@@ -1,0 +1,54 @@
+[
+  {
+    "rows": [
+      {
+        "title": "The Next 700 Programming Languages",
+        "author_if_has_functional_articles": {
+          "rows": []
+        }
+      },
+      {
+        "title": "Why Functional Programming Matters",
+        "author_if_has_functional_articles": {
+          "rows": [
+            {
+              "first_name": "John",
+              "last_name": "Hughes",
+              "articles": {
+                "rows": [
+                  {
+                    "title": "Why Functional Programming Matters"
+                  },
+                  {
+                    "title": "The Design And Implementation Of Programming Languages"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "title": "The Design And Implementation Of Programming Languages",
+        "author_if_has_functional_articles": {
+          "rows": [
+            {
+              "first_name": "John",
+              "last_name": "Hughes",
+              "articles": {
+                "rows": [
+                  {
+                    "title": "Why Functional Programming Matters"
+                  },
+                  {
+                    "title": "The Design And Implementation Of Programming Languages"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/ndc-reference/tests/query/predicate_with_unrelated_exists_and_relationship/request.json
+++ b/ndc-reference/tests/query/predicate_with_unrelated_exists_and_relationship/request.json
@@ -1,0 +1,110 @@
+{
+    "$schema": "../../../../ndc-client/tests/json_schema/query_request.jsonschema",
+    "collection": "articles",
+    "arguments": {},
+    "query": {
+        "fields": {
+            "title": {
+                "type": "column",
+                "column": "title"
+            },
+            "author_if_has_functional_articles": {
+                "type": "relationship",
+                "arguments": {},
+                "query": {
+                    "fields": {
+                        "first_name": {
+                            "type": "column",
+                            "column": "first_name"
+                        },
+                        "last_name": {
+                            "type": "column",
+                            "column": "last_name"
+                        },
+                        "articles": {
+                            "type": "relationship",
+                            "arguments": {},
+                            "relationship": "author_articles",
+                            "query": {
+                                "fields": {
+                                    "title": {
+                                        "type": "column",
+                                        "column": "title"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "where": {
+                        "type": "exists",
+                        "in_collection": {
+                            "type": "unrelated",
+                            "arguments": {},
+                            "collection": "articles"
+                        },
+                        "where": {
+                            "type": "and",
+                            "expressions": [
+                                {
+                                    "type": "binary_comparison_operator",
+                                    "column": {
+                                        "type": "column",
+                                        "name": "author_id",
+                                        "path": []
+                                    },
+                                    "operator": {
+                                        "type": "equal"
+                                    },
+                                    "value": {
+                                        "type": "column",
+                                        "column": {
+                                            "type": "root_collection_column",
+                                            "name": "id"
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "binary_comparison_operator",
+                                    "column": {
+                                        "type": "column",
+                                        "name": "title",
+                                        "path": []
+                                    },
+                                    "operator": {
+                                        "type": "other",
+                                        "name": "like"
+                                    },
+                                    "value": {
+                                        "type": "scalar",
+                                        "value": "Functional"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "relationship": "article_author"
+            }
+        }
+    },
+    "collection_relationships": {
+        "author_articles": {
+            "arguments": {},
+            "column_mapping": {
+                "id": "author_id"
+            },
+            "relationship_type": "array",
+            "source_collection_or_type": "author",
+            "target_collection": "articles"
+        },
+        "article_author": {
+            "arguments": {},
+            "column_mapping": {
+                "author_id": "id"
+            },
+            "relationship_type": "object",
+            "source_collection_or_type": "articles",
+            "target_collection": "authors"
+        }
+    }
+}

--- a/specification/src/specification/queries/filtering.md
+++ b/specification/src/specification/queries/filtering.md
@@ -113,6 +113,34 @@ See type [`ComparisonValue`](../../reference/types.md#comparisonvalue) for the v
 }
 ```
 
+### Columns in Operators
+
+Comparison operators compare columns to values. The column on the left hand side of any operator is described by a [`ComparisonTarget`](../../reference/types.md#comparisontarget), and the various cases will be explained next.
+
+#### Referencing a column from the same collection
+
+If the `ComparisonTarget` has type `column`, and the `path` property is empty, then the `name` property refers to a column in the current collection.
+
+#### Referencing a column from a related collection
+
+If the `ComparisonTarget` has type `column`, and the `path` property is non-empty, then the `name` property refers to column in a related collection. The path consists of a collection of [`PathElement`](../../reference/types.md#pathelement)s, each of which references a named [relationship](./relationships.md), any [collection arguments](./arguments.md), and a [predicate expression](./filtering.md) to be applied to any relevant rows in the related collection.
+
+When a `PathElement` references an _array_ relationship, the enclosing operator should be considered _existentially quantified_ over all related rows.
+
+#### Referencing a column from the root collection
+
+If the `ComparisonTarget` has type `root_collection_column`, then the `name` property refers to a column in the _root collection_.
+
+The root collection is defined as the collection in scope at the nearest enclosing [`Query`](../../reference/types.md#query), and the column should be chosen from the _row_ in that collection which was in scope when that `Query` was being evaluated.
+
+### Values in Binary Operators
+
+Binary (including array-valued) operators compare columns to _values_, but there are several types of valid values:
+
+- Scalar values, as seen in the examples above, compare the column to a specific value,
+- Variable values compare the column to the current value of a [variable](./variables.md),
+- Column values compare the column to _another_ column, possibly selected from a different collection. Column values are also described by a [`ComparisonTarget`](../../reference/types.md#comparisontarget).
+
 ## `EXISTS` expressions
 
 An `EXISTS` expression tests whether a row exists in some possibly-related collection, and is denoted by an expression with a `type` field of `exists`.
@@ -211,10 +239,6 @@ For example, to test if the `first_name` column is _not_ null:
     }
 }
 ```
-
-## Requirements
-
-_TODO_
 
 ## See also
 

--- a/specification/src/tutorial/queries/arguments.md
+++ b/specification/src/tutorial/queries/arguments.md
@@ -10,13 +10,7 @@ The first step is to evaluate each argument, which the `execute_query_with_varia
 {{#include ../../../../ndc-reference/bin/reference/main.rs:execute_query_with_variables}}
 ```
 
-Once this is complete, and we have a collection of evaluated `argument_values`, we can delegate to the `execute_query_by_collection_name` function, which will compute the collection itself:
-
-```rust,no_run,noplayground
-{{#include ../../../../ndc-reference/bin/reference/main.rs:execute_query_by_collection_name}}
-```
-
-The `get_collection_by_name` function peforms the work of computing the full collection, by pattern matching on the name of the collection:
+Once this is complete, and we have a collection of evaluated `argument_values`, we can delegate to the `get_collection_by_name` function. This function peforms the work of computing the full collection, by pattern matching on the name of the collection:
 
 ```rust,no_run,noplayground
 {{#include ../../../../ndc-reference/bin/reference/main.rs:get_collection_by_name}}

--- a/specification/src/tutorial/queries/execute/filtering.md
+++ b/specification/src/tutorial/queries/execute/filtering.md
@@ -38,7 +38,7 @@ The next category of expressions are the _unary operators_. The only unary opera
 To evaluate the comparison target, we delegate to the `eval_comparison_target` function, which pattern matches:
 
 - A column is evaluated using the `eval_path` function, which we will cover when we talk about [relationships](./relationships.md).
-- A _root collection_ column (that is, a column from the _root collection_, or collection used by the original query) is evaluated using `eval_column`. You may have noticed the additional argument, `root`, which has been passed down through every function call so far - this is to track the root collection for exactly this case.
+- A _root collection_ column (that is, a column from the _root collection_, or collection used by the nearest enclosing [`Query`](../../../reference/types.md#query)) is evaluated using `eval_column`. You may have noticed the additional argument, `root`, which has been passed down through every function call so far - this is to track the root collection for exactly this case.
 
 ```rust,no_run,noplayground
 {{#include ../../../../../ndc-reference/bin/reference/main.rs:eval_comparison_target}}


### PR DESCRIPTION
- [x] Reference implemenation
- [x] Tutorial
- [x] Specification
- [x] Test case

---

The concept of root collection should be scoped to the current `Query`, which means it gets reset at relationship boundaries but not at exists expressions.