### PR TITLE
bump opentelemetry to 0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
+checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -1044,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_api"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
+checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -1055,13 +1055,14 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "thiserror",
+ "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
+checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -1070,9 +1071,19 @@ dependencies = [
  "futures-util",
  "once_cell",
  "opentelemetry_api",
+ "ordered-float",
  "percent-encoding",
  "rand",
  "thiserror",
+]
+
+[[package]]
+name = "ordered-float"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126d3e6f3926bfb0fb24495b4f4da50626f547e54956594748e3d8882a0320b4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1830,6 +1841,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/ndc-client/Cargo.toml
+++ b/ndc-client/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.67"
 indexmap = { version = "1", features = ["serde"] }
-opentelemetry = "0.18.0"
+opentelemetry = "0.20.0"
 schemars = { version = "0.8.12", features = ["smol_str", "indexmap1"] }
 serde = "^1.0"
 serde_derive = "^1.0"


### PR DESCRIPTION
Would like to support trace response propagation on v3-engine-multitenant (spec [here](https://w3c.github.io/trace-context/#traceresponse-header)). This will be useful to propagate trace info to the client for further usage. 

The support was added from opentelemetry 0.19. I just upgraded it to 0.20 which is the latest version of the library