### PR TITLE
Updated test runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,6 +979,7 @@ dependencies = [
  "ndc-client",
  "proptest",
  "reqwest",
+ "semver",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1479,6 +1480,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -120,7 +120,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -206,6 +206,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +248,12 @@ name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -298,7 +319,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -402,7 +423,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.22",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -413,7 +434,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -531,7 +552,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -817,6 +838,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,7 +977,10 @@ dependencies = [
  "clap",
  "indexmap",
  "ndc-client",
+ "proptest",
  "reqwest",
+ "serde_json",
+ "thiserror",
  "tokio",
 ]
 
@@ -961,6 +991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1011,7 +1042,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1121,7 +1152,7 @@ checksum = "d1fef411b303e3e12d534fb6e7852de82da56edd937d895125821fb7c09436c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1173,10 +1204,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+dependencies = [
+ "bit-set",
+ "bitflags 1.3.2",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax 0.6.29",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1218,6 +1275,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,7 +1300,7 @@ checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -1242,6 +1308,12 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1327,6 +1399,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,22 +1482,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "d614f89548720367ded108b3c843be93f3a341e22d5674ca0dd5cd57f34926af"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "d4fe589678c688e44177da4f27152ee2d190757271dc7f1d5b6b9f68d869d641"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1429,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -1484,7 +1568,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1560,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1591,22 +1675,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1678,7 +1762,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1704,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-test"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53474327ae5e166530d17f2d956afcb4f8a004de581b3cae10f12006bc8163e3"
+checksum = "e89b3cbabd3ae862100094ae433e1def582cf86451b4e9bf83aa7ac1d8a7d719"
 dependencies = [
  "async-stream",
  "bytes",
@@ -1785,6 +1869,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,6 +1940,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,7 +1984,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -1919,7 +2018,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,11 +958,13 @@ dependencies = [
 name = "ndc-reference"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
  "csv",
  "goldenfile",
  "indexmap",
  "ndc-client",
+ "ndc-test",
  "prometheus",
  "regex",
  "serde_json",
@@ -974,6 +976,7 @@ dependencies = [
 name = "ndc-test"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "clap",
  "indexmap",
  "ndc-client",

--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ curl http://localhost:8100/schema | jq .
 ### Test an agent
 
 ```sh
-cargo run --bin ndc-test -- --endpoint http://localhost:8100
+cargo run --bin ndc-test -- test --endpoint http://localhost:8100
 ```

--- a/ndc-client/Cargo.toml
+++ b/ndc-client/Cargo.toml
@@ -5,10 +5,10 @@ description = "Protocol definitions and client library for the Hasura NDC specif
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1.67"
-indexmap = { version = "1", features = ["serde"] }
-opentelemetry = "0.18.0"
-schemars = { version = "0.8.12", features = ["smol_str", "indexmap1"] }
+async-trait = "^0.1.67"
+indexmap = { version = "^1", features = ["serde"] }
+opentelemetry = "^0.18.0"
+schemars = { version = "^0.8.12", features = ["smol_str", "indexmap1"] }
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
@@ -20,4 +20,4 @@ version = "^0.11"
 features = ["json", "multipart"]
 
 [dev-dependencies]
-goldenfile = "1.4.5"
+goldenfile = "^1.4.5"

--- a/ndc-client/src/apis/configuration.rs
+++ b/ndc-client/src/apis/configuration.rs
@@ -7,7 +7,6 @@ pub struct Configuration {
     pub oauth_access_token: Option<String>,
     pub bearer_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
-    pub seed: Option<String>,
 }
 
 pub type BasicAuth = (String, Option<String>);

--- a/ndc-client/src/apis/configuration.rs
+++ b/ndc-client/src/apis/configuration.rs
@@ -7,6 +7,7 @@ pub struct Configuration {
     pub oauth_access_token: Option<String>,
     pub bearer_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
+    pub seed: Option<String>,
 }
 
 pub type BasicAuth = (String, Option<String>);

--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -99,8 +99,6 @@ pub struct ObjectType {
 pub struct ObjectField {
     /// Description of this field
     pub description: Option<String>,
-    /// Any arguments that this object field accepts
-    pub arguments: BTreeMap<String, ArgumentInfo>,
     /// The type of this field
     #[serde(rename = "type")]
     pub r#type: Type,

--- a/ndc-client/tests/json_schema/schema_response.jsonschema
+++ b/ndc-client/tests/json_schema/schema_response.jsonschema
@@ -237,17 +237,9 @@
       "description": "The definition of an object field",
       "type": "object",
       "required": [
-        "arguments",
         "type"
       ],
       "properties": {
-        "arguments": {
-          "description": "Any arguments that this object field accepts",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/ArgumentInfo"
-          }
-        },
         "description": {
           "description": "Description of this field",
           "type": [

--- a/ndc-reference/Cargo.toml
+++ b/ndc-reference/Cargo.toml
@@ -9,20 +9,20 @@ path = "bin/reference/main.rs"
 
 [dependencies]
 ndc-client = { path = "../ndc-client" }
-indexmap = "1"
-serde_json = "1.0.92"
-tokio = { version = "1.26.0", features = [
+indexmap = "^1"
+serde_json = "^1.0.92"
+tokio = { version = "^1.26.0", features = [
     "macros",
     "rt-multi-thread",
     "parking_lot",
 ] }
-axum = "0.6.9"
-regex = "1.7.3"
-csv = "1.2.2"
-prometheus = "0.13.3"
+axum = "^0.6.9"
+regex = "^1.7.3"
+csv = "^1.2.2"
+prometheus = "^0.13.3"
 
 [dev-dependencies]
-async-trait = "0.1.67"
-goldenfile = "1.4.5"
-tokio-test = "0.4.2"
+async-trait = "^0.1.67"
+goldenfile = "^1.4.5"
+tokio-test = "^0.4.2"
 ndc-test = { path = "../ndc-test" }

--- a/ndc-reference/Cargo.toml
+++ b/ndc-reference/Cargo.toml
@@ -22,5 +22,7 @@ csv = "1.2.2"
 prometheus = "0.13.3"
 
 [dev-dependencies]
+async-trait = "0.1.67"
 goldenfile = "1.4.5"
 tokio-test = "0.4.2"
+ndc-test = { path = "../ndc-test" }

--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -235,7 +235,6 @@ async fn get_schema() -> Json<models::SchemaResponse> {
                 "id".into(),
                 models::ObjectField {
                     description: Some("The article's primary key".into()),
-                    arguments: BTreeMap::new(),
                     r#type: models::Type::Named { name: "Int".into() },
                 },
             ),
@@ -243,7 +242,6 @@ async fn get_schema() -> Json<models::SchemaResponse> {
                 "title".into(),
                 models::ObjectField {
                     description: Some("The article's title".into()),
-                    arguments: BTreeMap::new(),
                     r#type: models::Type::Named {
                         name: "String".into(),
                     },
@@ -253,7 +251,6 @@ async fn get_schema() -> Json<models::SchemaResponse> {
                 "author_id".into(),
                 models::ObjectField {
                     description: Some("The article's author ID".into()),
-                    arguments: BTreeMap::new(),
                     r#type: models::Type::Named { name: "Int".into() },
                 },
             ),
@@ -268,7 +265,6 @@ async fn get_schema() -> Json<models::SchemaResponse> {
                 "id".into(),
                 models::ObjectField {
                     description: Some("The author's primary key".into()),
-                    arguments: BTreeMap::new(),
                     r#type: models::Type::Named { name: "Int".into() },
                 },
             ),
@@ -276,7 +272,6 @@ async fn get_schema() -> Json<models::SchemaResponse> {
                 "first_name".into(),
                 models::ObjectField {
                     description: Some("The author's first name".into()),
-                    arguments: BTreeMap::new(),
                     r#type: models::Type::Named {
                         name: "String".into(),
                     },
@@ -286,7 +281,6 @@ async fn get_schema() -> Json<models::SchemaResponse> {
                 "last_name".into(),
                 models::ObjectField {
                     description: Some("The author's last name".into()),
-                    arguments: BTreeMap::new(),
                     r#type: models::Type::Named {
                         name: "String".into(),
                     },

--- a/ndc-reference/tests/schema/expected.json
+++ b/ndc-reference/tests/schema/expected.json
@@ -43,7 +43,6 @@
       "fields": {
         "author_id": {
           "description": "The article's author ID",
-          "arguments": {},
           "type": {
             "type": "named",
             "name": "Int"
@@ -51,7 +50,6 @@
         },
         "id": {
           "description": "The article's primary key",
-          "arguments": {},
           "type": {
             "type": "named",
             "name": "Int"
@@ -59,7 +57,6 @@
         },
         "title": {
           "description": "The article's title",
-          "arguments": {},
           "type": {
             "type": "named",
             "name": "String"
@@ -72,7 +69,6 @@
       "fields": {
         "first_name": {
           "description": "The author's first name",
-          "arguments": {},
           "type": {
             "type": "named",
             "name": "String"
@@ -80,7 +76,6 @@
         },
         "id": {
           "description": "The author's primary key",
-          "arguments": {},
           "type": {
             "type": "named",
             "name": "Int"
@@ -88,7 +83,6 @@
         },
         "last_name": {
           "description": "The author's last name",
-          "arguments": {},
           "type": {
             "type": "named",
             "name": "String"

--- a/ndc-test/Cargo.toml
+++ b/ndc-test/Cargo.toml
@@ -5,13 +5,13 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-async-trait = "0.1.67"
-clap = { version = "4", features = ["derive"] }
-indexmap = { version = "1", features = ["serde"] }
+async-trait = "^0.1.67"
+clap = { version = "^4", features = ["derive"] }
+indexmap = { version = "^1", features = ["serde"] }
 ndc-client = { path = "../ndc-client" }
-proptest = "1.2.0"
+proptest = "^1.2.0"
 reqwest = { version = "^0.11", features = ["json", "multipart"] }
-semver = "1.0.18"
-serde_json = "1.0.105"
-thiserror = "1.0.47"
-tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread", "parking_lot"] }
+semver = "^1.0.18"
+serde_json = "^1.0.105"
+thiserror = "^1.0.47"
+tokio = { version = "^1.26.0", features = ["macros", "rt-multi-thread", "parking_lot"] }

--- a/ndc-test/Cargo.toml
+++ b/ndc-test/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+async-trait = "0.1.67"
 clap = { version = "4", features = ["derive"] }
 indexmap = { version = "1", features = ["serde"] }
 ndc-client = { path = "../ndc-client" }

--- a/ndc-test/Cargo.toml
+++ b/ndc-test/Cargo.toml
@@ -7,10 +7,9 @@ edition.workspace = true
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 indexmap = { version = "1", features = ["serde"] }
-tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread", "parking_lot"] }
-
 ndc-client = { path = "../ndc-client" }
-
-[dependencies.reqwest]
-version = "^0.11"
-features = ["json", "multipart"]
+proptest = "1.2.0"
+reqwest = { version = "^0.11", features = ["json", "multipart"] }
+serde_json = "1.0.105"
+thiserror = "1.0.47"
+tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread", "parking_lot"] }

--- a/ndc-test/Cargo.toml
+++ b/ndc-test/Cargo.toml
@@ -10,6 +10,7 @@ indexmap = { version = "1", features = ["serde"] }
 ndc-client = { path = "../ndc-client" }
 proptest = "1.2.0"
 reqwest = { version = "^0.11", features = ["json", "multipart"] }
+semver = "1.0.18"
 serde_json = "1.0.105"
 thiserror = "1.0.47"
 tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread", "parking_lot"] }

--- a/ndc-test/src/lib.rs
+++ b/ndc-test/src/lib.rs
@@ -1,166 +1,462 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
+use std::future::Future;
 
 use indexmap::IndexMap;
 use ndc_client::apis::configuration::Configuration;
 use ndc_client::apis::default_api as api;
 use ndc_client::models;
+use proptest::sample::select;
+use proptest::strategy::{Strategy, Union, ValueTree};
+use proptest::test_runner::{Config, Reason, RngAlgorithm, TestRng, TestRunner};
+use thiserror::Error;
 
-pub async fn test_connector(configuration: &Configuration) -> Result<(), ndc_client::apis::Error> {
-    println!("Fetching /capabilities");
-    let capabilities = api::capabilities_get(configuration).await?;
-    println!("Validating capabilities");
-    validate_capabilities(&capabilities);
+#[derive(Debug, Error)]
+pub enum TestFailure {
+    #[error("error communicating with the connector: {0}")]
+    CommunicationError(ndc_client::apis::Error),
+    #[error("error generating test data: {0}")]
+    StrategyError(Reason),
+    #[error("collection type {0} is not a defined object type")]
+    CollectionTypeIsNotDefined(String),
+    #[error("named type {0} is not a defined object or scalar type")]
+    NamedTypeIsNotDefined(String),
+    #[error("insertable column {0} is not defined on collection type")]
+    InsertableColumnNotDefined(String),
+    #[error("updatable column {0} is not defined on collection type")]
+    UpdatableColumnNotDefined(String),
+    #[error("expected null rows in RowSet")]
+    RowsShouldBeNullInRowSet,
+    #[error("expected non-null rows in RowSet")]
+    RowsShouldBeNonNullInRowSet,
+    #[error("expected null aggregates in RowSet")]
+    AggregatesShouldBeNullInRowSet,
+    #[error("expected non-null aggregates in RowSet")]
+    AggregatesShouldBeNonNullInRowSet,
+    #[error("expected a single RowSet in the QueryResponse")]
+    ExpectedSingleRowSet,
+    #[error("expected non-empty rows in RowSet")]
+    ExpectedNonEmptyRows,
+    #[error("requested field {0} was missing in response")]
+    MissingField(String),
+}
 
-    print!("Fetching /schema");
-    let schema = api::schema_get(configuration).await.unwrap();
-    println!("Validating schema");
-    validate_schema(&schema);
+impl From<ndc_client::apis::Error> for TestFailure {
+    fn from(value: ndc_client::apis::Error) -> Self {
+        TestFailure::CommunicationError(value)
+    }
+}
 
-    println!("Testing /query");
-    test_query(configuration, &capabilities, &schema).await;
+impl From<Reason> for TestFailure {
+    fn from(value: Reason) -> Self {
+        TestFailure::StrategyError(value)
+    }
+}
+
+async fn test<A, F: Future<Output = Result<A, TestFailure>>>(
+    name: &str,
+    level: usize,
+    f: F,
+) -> Result<A, TestFailure> {
+    let spaces = "  ".repeat(level);
+    print!("{spaces}∟ {name} ...");
+
+    match f.await {
+        Ok(result) => {
+            println!(" \x1b[1;32mOK\x1b[22;0m");
+            Ok(result)
+        }
+        Err(err) => {
+            println!(" \x1b[1;31mFAIL\x1b[22;0m");
+            eprintln!("{name} failed with message {}", err.to_string());
+            Err(err)
+        }
+    }
+}
+
+fn nest(name: &str, level: usize) {
+    let spaces = "  ".repeat(level);
+    println!("{spaces}∟ {name} ...");
+}
+
+pub async fn test_connector(configuration: &Configuration) -> Result<(), TestFailure> {
+    let mut runner = TestRunner::new_with_rng(
+        Config::default(),
+        match &configuration.seed {
+            Some(seed) => TestRng::from_seed(RngAlgorithm::XorShift, &seed.as_bytes()),
+            None => TestRng::deterministic_rng(RngAlgorithm::XorShift),
+        },
+    );
+
+    println!("Capabilities");
+    let capabilities = async {
+        let capabilities = test("Fetching /capabilities ...", 1, async {
+            Ok(api::capabilities_get(configuration).await?)
+        })
+        .await?;
+
+        let _ = test("Validating capabilities", 1, async {
+            validate_capabilities(&capabilities)
+        })
+        .await;
+
+        Ok::<_, TestFailure>(capabilities)
+    }
+    .await?;
+
+    println!("Schema");
+    let schema = async {
+        let schema = test("Fetching /schema", 1, async {
+            Ok(api::schema_get(configuration).await?)
+        })
+        .await?;
+
+        nest("Validating schema", 1);
+        let _ = validate_schema(&schema).await;
+
+        Ok::<_, TestFailure>(schema)
+    }
+    .await?;
+
+    println!("Query");
+
+    test_query(configuration, &capabilities, &schema, &mut runner).await;
 
     Ok(())
 }
 
-pub fn validate_capabilities(_capabilities: &models::CapabilitiesResponse) {
+pub fn validate_capabilities(
+    _capabilities: &models::CapabilitiesResponse,
+) -> Result<(), TestFailure> {
     // TODO: validate capabilities.version
+    Ok(())
 }
 
-pub fn validate_schema(schema: &models::SchemaResponse) {
-    println!("Validating object_types");
-    for (_type_name, object_type) in schema.object_types.iter() {
-        for (_field_name, object_field) in object_type.fields.iter() {
-            validate_type(schema, &object_field.r#type);
-            for (_arg_name, arg_info) in object_field.arguments.iter() {
-                validate_type(schema, &arg_info.argument_type);
+pub async fn validate_schema(schema: &models::SchemaResponse) -> Result<(), TestFailure> {
+    let _ = test("object_types", 2, async {
+        for (_type_name, object_type) in schema.object_types.iter() {
+            for (_field_name, object_field) in object_type.fields.iter() {
+                validate_type(schema, &object_field.r#type)?;
             }
         }
-    }
+        Ok(())
+    })
+    .await;
 
-    println!("Validating collections");
+    nest("Collections", 2);
+
     for collection_info in schema.collections.iter() {
-        println!("Validating collection {}", collection_info.name);
-        let collection_type = schema
-            .object_types
-            .get(collection_info.collection_type.as_str());
+        nest(collection_info.name.as_str(), 3);
 
-        for (_arg_name, arg_info) in collection_info.arguments.iter() {
-            validate_type(schema, &arg_info.argument_type);
-        }
-
-        match collection_type {
-            None => {
-                panic!(
-                    "collection type {} is not a defined object type",
-                    collection_info.collection_type
-                );
+        let _ = test("Arguments", 4, async {
+            for (_arg_name, arg_info) in collection_info.arguments.iter() {
+                validate_type(schema, &arg_info.argument_type)?;
             }
+            Ok(())
+        })
+        .await;
 
-            Some(collection_type) => {
-                println!("Validating columns");
-                if let Some(insertable_columns) = &collection_info.insertable_columns {
-                    for insertable_column in insertable_columns.iter() {
-                        assert!(
-                            collection_type
-                                .fields
-                                .contains_key(insertable_column.as_str()),
-                            "insertable column {} is not defined on collection type",
-                            insertable_column
-                        );
-                    }
-                }
-                if let Some(updatable_columns) = &collection_info.updatable_columns {
-                    for updatable_column in updatable_columns.iter() {
-                        assert!(
-                            collection_type
-                                .fields
-                                .contains_key(updatable_column.as_str()),
-                            "updatable column {} is not defined on collection type",
-                            updatable_column
-                        );
+        let _ = test("Collection type", 4, async {
+            let collection_type = schema
+                .object_types
+                .get(collection_info.collection_type.as_str())
+                .ok_or(TestFailure::CollectionTypeIsNotDefined(
+                    collection_info.collection_type.clone(),
+                ))?;
+
+            if let Some(insertable_columns) = &collection_info.insertable_columns {
+                for insertable_column in insertable_columns.iter() {
+                    if !collection_type
+                        .fields
+                        .contains_key(insertable_column.as_str())
+                    {
+                        return Err(TestFailure::InsertableColumnNotDefined(
+                            insertable_column.clone(),
+                        ));
                     }
                 }
             }
-        };
+            if let Some(updatable_columns) = &collection_info.updatable_columns {
+                for updatable_column in updatable_columns.iter() {
+                    if !collection_type
+                        .fields
+                        .contains_key(updatable_column.as_str())
+                    {
+                        return Err(TestFailure::UpdatableColumnNotDefined(
+                            updatable_column.clone(),
+                        ));
+                    }
+                }
+            }
+
+            Ok(())
+        })
+        .await;
     }
 
-    println!("Validating functions");
+    nest("Functions", 2);
+
     for function_info in schema.functions.iter() {
-        println!("Validating function {}", function_info.name);
-        validate_type(schema, &function_info.result_type);
+        nest(function_info.name.as_str(), 3);
 
-        for (_arg_name, arg_info) in function_info.arguments.iter() {
-            validate_type(schema, &arg_info.argument_type);
-        }
+        let _ = test("Result type", 4, async {
+            validate_type(schema, &function_info.result_type)
+        })
+        .await;
+
+        let _ = test("Arguments", 4, async {
+            for (_arg_name, arg_info) in function_info.arguments.iter() {
+                validate_type(schema, &arg_info.argument_type)?;
+            }
+
+            Ok(())
+        })
+        .await;
     }
 
-    println!("Validating procedures");
+    nest("Procedures", 2);
+
     for procedure_info in schema.procedures.iter() {
-        println!("Validating procedure {}", procedure_info.name);
+        nest(procedure_info.name.as_str(), 3);
 
-        validate_type(schema, &procedure_info.result_type);
+        let _ = test("Result type", 4, async {
+            validate_type(schema, &procedure_info.result_type)
+        })
+        .await;
 
-        for (_arg_name, arg_info) in procedure_info.arguments.iter() {
-            validate_type(schema, &arg_info.argument_type);
-        }
+        let _ = test("Arguments", 4, async {
+            for (_arg_name, arg_info) in procedure_info.arguments.iter() {
+                validate_type(schema, &arg_info.argument_type)?;
+            }
+
+            Ok(())
+        })
+        .await;
     }
+
+    Ok(())
 }
 
-pub fn validate_type(schema: &models::SchemaResponse, r#type: &models::Type) {
+pub fn validate_type(
+    schema: &models::SchemaResponse,
+    r#type: &models::Type,
+) -> Result<(), TestFailure> {
     match r#type {
         models::Type::Named { name } => {
-            assert!(
-                schema.object_types.contains_key(name.as_str())
-                    || schema.scalar_types.contains_key(name.as_str()),
-                "named type {} is not a defined object or scalar type",
-                name
-            );
+            if !schema.object_types.contains_key(name.as_str())
+                && !schema.scalar_types.contains_key(name.as_str())
+            {
+                return Err(TestFailure::NamedTypeIsNotDefined(name.clone()));
+            }
         }
         models::Type::Array { element_type } => {
-            validate_type(schema, element_type);
+            validate_type(schema, element_type)?;
         }
         models::Type::Nullable { underlying_type } => {
-            validate_type(schema, underlying_type);
+            validate_type(schema, underlying_type)?;
         }
     }
+
+    Ok(())
 }
 
 pub async fn test_query(
     configuration: &Configuration,
     _capabilities: &models::CapabilitiesResponse,
     schema: &models::SchemaResponse,
+    runner: &mut TestRunner,
 ) {
-    println!("Testing simple queries");
     for collection_info in schema.collections.iter() {
-        if collection_info.arguments.is_empty() {
-            println!("Querying collection {}", collection_info.name);
-            test_simple_queries(configuration, schema, collection_info).await;
-        } else {
-            println!("Skipping parameterized collection {}", collection_info.name);
-        }
-    }
+        nest(collection_info.name.as_str(), 1);
 
-    println!("Testing aggregate queries");
-    for collection_info in schema.collections.iter() {
         if collection_info.arguments.is_empty() {
-            println!("Querying collection {}", collection_info.name);
-            test_aggregate_queries(configuration, schema, collection_info).await;
+            nest("Simple queries", 2);
+
+            let _ = test_simple_queries(runner, configuration, schema, collection_info).await;
+
+            nest("Aggregate queries", 2);
+
+            let _ = test_aggregate_queries(configuration, schema, collection_info).await;
         } else {
-            println!("Skipping parameterized collection {}", collection_info.name);
+            eprintln!("Skipping parameterized collection {}", collection_info.name);
         }
     }
 }
 
 async fn test_simple_queries(
+    runner: &mut TestRunner,
     configuration: &Configuration,
     schema: &models::SchemaResponse,
     collection_info: &models::CollectionInfo,
-) {
+) -> Result<(), TestFailure> {
     let collection_type = schema
         .object_types
         .get(collection_info.collection_type.as_str())
-        .unwrap();
-    let fields = collection_type
+        .ok_or(TestFailure::CollectionTypeIsNotDefined(
+            collection_info.collection_type.clone(),
+        ))?;
+
+    let rows = test("Select top N", 3, test_select_top_n_rows(collection_type, collection_info, configuration)).await?;
+
+    let value_strategies = make_value_strategies(rows, collection_type)?;
+
+    if let Some(expression_strategy) = make_expression_strategies(value_strategies) {
+        let _ = test("Predicates", 3, async {
+            for _ in 1..10 {
+                test_select_top_n_rows_with_predicate(
+                    runner,
+                    &expression_strategy,
+                    collection_type,
+                    collection_info,
+                    configuration,
+                )
+                .await?;
+            }
+
+            Ok(())
+        }).await?;
+    } else {
+        eprintln!("Skipping empty collection {}", collection_info.name);
+    }
+
+    Ok(())
+}
+
+async fn test_select_top_n_rows(
+    collection_type: &models::ObjectType,
+    collection_info: &models::CollectionInfo,
+    configuration: &Configuration,
+) -> Result<Vec<IndexMap<String, models::RowFieldValue>>, TestFailure> {
+    let fields = select_all_columns(collection_type);
+    let query_request = models::QueryRequest {
+        collection: collection_info.name.clone(),
+        query: models::Query {
+            aggregates: None,
+            fields: Some(fields.clone()),
+            limit: Some(10),
+            offset: None,
+            order_by: None,
+            predicate: None,
+        },
+        arguments: BTreeMap::new(),
+        collection_relationships: BTreeMap::new(),
+        variables: None,
+    };
+
+    let response = api::query_post(configuration, query_request)
+        .await?;
+
+    if response.0.len() != 1 {
+        return Err(TestFailure::ExpectedSingleRowSet);
+    }
+
+    let row_set = response.0[0].clone();
+
+    row_set.rows.ok_or(TestFailure::RowsShouldBeNonNullInRowSet)
+}
+
+async fn test_select_top_n_rows_with_predicate(
+    runner: &mut TestRunner,
+    expression_strategy: &impl Strategy<Value = models::Expression>,
+    collection_type: &models::ObjectType,
+    collection_info: &models::CollectionInfo,
+    configuration: &Configuration,
+) -> Result<(), TestFailure> {
+    if let Ok(tree) = expression_strategy.new_tree(runner) {
+        let predicate = tree.current();
+
+        let fields = select_all_columns(collection_type);
+
+        let query_request = models::QueryRequest {
+            collection: collection_info.name.clone(),
+            query: models::Query {
+                aggregates: None,
+                fields: Some(fields),
+                limit: Some(10),
+                offset: None,
+                order_by: None,
+                predicate: Some(predicate),
+            },
+            arguments: BTreeMap::new(),
+            collection_relationships: BTreeMap::new(),
+            variables: None,
+        };
+
+        let response = api::query_post(configuration, query_request)
+            .await?;
+
+        if response.0.len() != 1 {
+            return Err(TestFailure::ExpectedSingleRowSet);
+        }
+
+        let row_set = response.0.first().unwrap();
+        let rows = row_set
+            .rows
+            .as_ref()
+            .ok_or(TestFailure::RowsShouldBeNonNullInRowSet)?;
+
+        if rows.is_empty() {
+            return Err(TestFailure::ExpectedNonEmptyRows);
+        }
+    }
+
+    Ok(())
+}
+
+fn make_value_strategies(
+    rows: Vec<IndexMap<String, models::RowFieldValue>>,
+    collection_type: &models::ObjectType,
+) -> Result<HashMap<String, impl Strategy<Value = serde_json::Value>>, TestFailure> {
+    let mut values: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
+
+    for row in rows {
+        for (field_name, _) in collection_type.fields.iter() {
+            if !row.contains_key(field_name.as_str()) {
+                panic!("field {0} was missing in query response", field_name)
+            }
+        }
+
+        for (field_name, field_value) in row {
+            values
+                .entry(field_name.clone())
+                .or_insert(vec![])
+                .push(field_value.0.clone());
+        }
+    }
+
+    let strategies = values
+        .into_iter()
+        .map(|(field_name, examples)| Ok((field_name, select(examples))))
+        .collect::<Result<HashMap<String, _>, Reason>>()?;
+
+    Ok(strategies)
+}
+
+fn make_expression_strategies<S: Strategy<Value = serde_json::Value>>(
+    value_strategies: HashMap<String, S>,
+) -> Option<impl Strategy<Value = models::Expression>> {
+    let expression_strategies = value_strategies
+        .into_iter()
+        .map(|(field_name, strategy)| {
+            strategy.prop_map(move |value| models::Expression::BinaryComparisonOperator {
+                column: Box::new(models::ComparisonTarget::Column {
+                    name: field_name.clone(),
+                    path: vec![],
+                }),
+                operator: Box::new(models::BinaryComparisonOperator::Equal),
+                value: Box::new(models::ComparisonValue::Scalar { value }),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if expression_strategies.is_empty() {
+        None
+    } else {
+        Some(Union::new(expression_strategies))
+    }
+}
+
+fn select_all_columns(collection_type: &models::ObjectType) -> IndexMap<String, models::Field> {
+    collection_type
         .fields
         .iter()
         .map(|f| {
@@ -171,31 +467,14 @@ async fn test_simple_queries(
                 },
             )
         })
-        .collect::<IndexMap<String, models::Field>>();
-    let query_request = models::QueryRequest {
-        collection: collection_info.name.clone(),
-        query: models::Query {
-            aggregates: None,
-            fields: Some(fields),
-            limit: Some(10),
-            offset: None,
-            order_by: None,
-            predicate: None,
-        },
-        arguments: BTreeMap::new(),
-        collection_relationships: BTreeMap::new(),
-        variables: None,
-    };
-    let _response = api::query_post(configuration, query_request).await;
-
-    // TODO: assert the response matches the type
+        .collect::<IndexMap<String, models::Field>>()
 }
 
 async fn test_aggregate_queries(
     configuration: &Configuration,
     _schema: &models::SchemaResponse,
     collection_info: &models::CollectionInfo,
-) {
+) -> Result<(), TestFailure> {
     let aggregates = IndexMap::from([("count".into(), models::Aggregate::StarCount {})]);
     let query_request = models::QueryRequest {
         collection: collection_info.name.clone(),
@@ -212,20 +491,21 @@ async fn test_aggregate_queries(
         variables: None,
     };
     let response = api::query_post(configuration, query_request).await.unwrap();
+    
     if let [row_set] = &*response.0 {
-        assert!(
-            row_set.rows.is_none(),
-            "aggregate-only query should not return rows"
-        );
+        if row_set.rows.is_some() {
+            return Err(TestFailure::RowsShouldBeNullInRowSet);
+        }
         if let Some(aggregates) = &row_set.aggregates {
-            assert!(
-                aggregates.contains_key("count"),
-                "aggregate query should return requested count aggregate"
-            );
+            if !aggregates.contains_key("count") {
+                return Err(TestFailure::MissingField("count".into()));
+            }
         } else {
-            panic!("aggregate query should return aggregates");
+            return Err(TestFailure::AggregatesShouldBeNonNullInRowSet);
         }
     } else {
-        panic!("response should return a single rowset");
+        return Err(TestFailure::ExpectedSingleRowSet);
     }
+
+    Ok(())
 }

--- a/ndc-test/src/lib.rs
+++ b/ndc-test/src/lib.rs
@@ -176,9 +176,11 @@ async fn run_all_tests<C: Connector>(
     println!("Capabilities");
 
     let capabilities = async {
-        let capabilities = test("Fetching /capabilities ...", results, async {
-            Ok(connector.get_capabilities().await?)
-        })
+        let capabilities = test(
+            "Fetching /capabilities ...",
+            results,
+            connector.get_capabilities(),
+        )
         .await?;
 
         let _ = test("Validating capabilities", results, async {
@@ -192,10 +194,7 @@ async fn run_all_tests<C: Connector>(
 
     println!("Schema");
     let schema = async {
-        let schema = test("Fetching /schema", results, async {
-            Ok(connector.get_schema().await?)
-        })
-        .await?;
+        let schema = test("Fetching /schema", results, connector.get_schema()).await?;
 
         nest("Validating schema", results, async {
             validate_schema(&schema, results).await

--- a/ndc-test/src/lib.rs
+++ b/ndc-test/src/lib.rs
@@ -73,7 +73,8 @@ pub struct TestResults {
 
 #[derive(Debug)]
 pub struct FailedTest {
-    pub test_name: String,
+    pub path: Vec<String>,
+    pub name: String,
     pub error: Error,
 }
 
@@ -84,8 +85,8 @@ async fn test<A, F: Future<Output = Result<A, Error>>>(
 ) -> Option<A> {
     let mut results_mut = results.borrow_mut();
     let level = results_mut.path.len();
-    let spaces = "  ".repeat(level);
-    print!("{spaces}∟ {name} ...");
+    let spaces = "│ ".repeat(level);
+    print!("{spaces}├ {name} ...");
 
     match f.await {
         Ok(result) => {
@@ -94,8 +95,10 @@ async fn test<A, F: Future<Output = Result<A, Error>>>(
         }
         Err(err) => {
             println!(" \x1b[1;31mFAIL\x1b[22;0m");
+            let path = results_mut.path.clone();
             results_mut.failures.push(FailedTest {
-                test_name: name.into(),
+                path,
+                name: name.into(),
                 error: err,
             });
             None
@@ -107,8 +110,8 @@ async fn nest<A, F: Future<Output = A>>(name: &str, results: &RefCell<TestResult
     {
         let mut results_mut = results.borrow_mut();
         let level = results_mut.path.len();
-        let spaces = "  ".repeat(level);
-        println!("{spaces}∟ {name} ...");
+        let spaces = "│ ".repeat(level);
+        println!("{spaces}├ {name} ...");
         results_mut.path.push(name.into());
     }
     let result = f.await;

--- a/ndc-test/src/lib.rs
+++ b/ndc-test/src/lib.rs
@@ -83,10 +83,12 @@ async fn test<A, F: Future<Output = Result<A, Error>>>(
     results: &RefCell<TestResults>,
     f: F,
 ) -> Option<A> {
-    let mut results_mut = results.borrow_mut();
-    let level = results_mut.path.len();
-    let spaces = "│ ".repeat(level);
-    print!("{spaces}├ {name} ...");
+    {
+        let results = results.borrow();
+        let level = results.path.len();
+        let spaces = "│ ".repeat(level);
+        print!("{spaces}├ {name} ...");
+    }
 
     match f.await {
         Ok(result) => {
@@ -94,6 +96,7 @@ async fn test<A, F: Future<Output = Result<A, Error>>>(
             Some(result)
         }
         Err(err) => {
+            let mut results_mut = results.borrow_mut();
             println!(" \x1b[1;31mFAIL\x1b[22;0m");
             let path = results_mut.path.clone();
             results_mut.failures.push(FailedTest {
@@ -255,7 +258,8 @@ pub async fn validate_schema(
                     }
 
                     Ok(())
-                });
+                })
+                .await;
             })
             .await;
         }

--- a/ndc-test/src/lib.rs
+++ b/ndc-test/src/lib.rs
@@ -67,7 +67,7 @@ async fn test<A, F: Future<Output = Result<A, TestFailure>>>(
         }
         Err(err) => {
             println!(" \x1b[1;31mFAIL\x1b[22;0m");
-            eprintln!("{name} failed with message {}", err.to_string());
+            eprintln!("{name} failed with message {}", err);
             Err(err)
         }
     }
@@ -82,7 +82,7 @@ pub async fn test_connector(configuration: &Configuration) -> Result<(), TestFai
     let mut runner = TestRunner::new_with_rng(
         Config::default(),
         match &configuration.seed {
-            Some(seed) => TestRng::from_seed(RngAlgorithm::XorShift, &seed.as_bytes()),
+            Some(seed) => TestRng::from_seed(RngAlgorithm::XorShift, seed.as_bytes()),
             None => TestRng::deterministic_rng(RngAlgorithm::XorShift),
         },
     );
@@ -300,7 +300,7 @@ async fn test_simple_queries(
     let value_strategies = make_value_strategies(rows, collection_type)?;
 
     if let Some(expression_strategy) = make_expression_strategies(value_strategies) {
-        let _ = test("Predicates", 3, async {
+        test("Predicates", 3, async {
             for _ in 1..10 {
                 test_select_top_n_rows_with_predicate(
                     runner,

--- a/ndc-test/src/main.rs
+++ b/ndc-test/src/main.rs
@@ -1,6 +1,7 @@
+use std::process::exit;
+
 use clap::{Parser, Subcommand};
 use ndc_client::apis::configuration::Configuration;
-use ndc_test::TestFailure;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -21,7 +22,7 @@ enum Commands {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), TestFailure> {
+async fn main() -> () {
     match Options::parse().command {
         Commands::Test {
             endpoint,
@@ -38,7 +39,12 @@ async fn main() -> Result<(), TestFailure> {
                 seed,
             };
 
-            ndc_test::test_connector(&configuration).await
+            let results = ndc_test::test_connector(&configuration).await;
+
+            if !results.failures.is_empty() {
+                println!("\x1b[1;31mFailed with {0} test failures, see stderr for details.\x1b[22;0m", results.failures.len());
+                exit(1)
+            }
         }
     }
 }

--- a/ndc-test/src/main.rs
+++ b/ndc-test/src/main.rs
@@ -22,7 +22,7 @@ enum Commands {
 }
 
 #[tokio::main]
-async fn main() -> () {
+async fn main() {
     match Options::parse().command {
         Commands::Test { endpoint, seed } => {
             let configuration = Configuration {

--- a/ndc-test/src/main.rs
+++ b/ndc-test/src/main.rs
@@ -24,10 +24,7 @@ enum Commands {
 #[tokio::main]
 async fn main() -> () {
     match Options::parse().command {
-        Commands::Test {
-            endpoint,
-            seed,
-        } => {
+        Commands::Test { endpoint, seed } => {
             let configuration = Configuration {
                 base_path: endpoint,
                 user_agent: None,
@@ -42,7 +39,23 @@ async fn main() -> () {
             let results = ndc_test::test_connector(&configuration).await;
 
             if !results.failures.is_empty() {
-                println!("\x1b[1;31mFailed with {0} test failures, see stderr for details.\x1b[22;0m", results.failures.len());
+                println!();
+                println!(
+                    "\x1b[1;31mFailed with {0} test failures:\x1b[22;0m",
+                    results.failures.len()
+                );
+
+                let mut ix = 1;
+                for failure in results.failures {
+                    println!();
+                    println!("[{0}] {1}", ix, failure.name);
+                    for path_element in failure.path {
+                        println!("  in {0}", path_element);
+                    }
+                    println!("Details: {0}", failure.error);
+                    ix += 1;
+                }
+
                 exit(1)
             }
         }

--- a/ndc-test/src/main.rs
+++ b/ndc-test/src/main.rs
@@ -2,6 +2,7 @@ use std::process::exit;
 
 use clap::{Parser, Subcommand};
 use ndc_client::apis::configuration::Configuration;
+use ndc_test::TestConfiguration;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -25,6 +26,8 @@ enum Commands {
 async fn main() {
     match Options::parse().command {
         Commands::Test { endpoint, seed } => {
+            let test_configuration = TestConfiguration { seed };
+
             let configuration = Configuration {
                 base_path: endpoint,
                 user_agent: None,
@@ -33,10 +36,9 @@ async fn main() {
                 oauth_access_token: None,
                 bearer_access_token: None,
                 api_key: None,
-                seed,
             };
 
-            let results = ndc_test::test_connector(&configuration).await;
+            let results = ndc_test::test_connector(&test_configuration, &configuration).await;
 
             if !results.failures.is_empty() {
                 println!();

--- a/ndc-test/src/main.rs
+++ b/ndc-test/src/main.rs
@@ -1,24 +1,44 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use ndc_client::apis::configuration::Configuration;
+use ndc_test::TestFailure;
 
 #[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+#[command(propagate_version = true)]
 struct Options {
-    #[arg(long, value_name = "ENDPOINT")]
-    endpoint: String,
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Test {
+        #[arg(long, value_name = "ENDPOINT")]
+        endpoint: String,
+        #[arg(long, value_name = "SEED")]
+        seed: Option<String>,
+    },
 }
 
 #[tokio::main]
-async fn main() -> Result<(), ndc_client::apis::Error> {
-    let options = Options::parse();
-    let configuration = Configuration {
-        base_path: options.endpoint,
-        user_agent: None,
-        client: reqwest::Client::new(),
-        basic_auth: None,
-        oauth_access_token: None,
-        bearer_access_token: None,
-        api_key: None,
-    };
+async fn main() -> Result<(), TestFailure> {
+    match Options::parse().command {
+        Commands::Test {
+            endpoint,
+            seed,
+        } => {
+            let configuration = Configuration {
+                base_path: endpoint,
+                user_agent: None,
+                client: reqwest::Client::new(),
+                basic_auth: None,
+                oauth_access_token: None,
+                bearer_access_token: None,
+                api_key: None,
+                seed,
+            };
 
-    ndc_test::test_connector(&configuration).await
+            ndc_test::test_connector(&configuration).await
+        }
+    }
 }

--- a/specification/src/tutorial/testing.md
+++ b/specification/src/tutorial/testing.md
@@ -15,32 +15,47 @@ ndc-test --endpoint <ENDPOINT>
 For example, running the reference connector and passing its URL to `ndc-test`, we will see that it issues test queries against the `articles` and `authors` collections:
 
 ```text
-ndc-test --ent http://localhost:8100
+ndc-test test --endpoint http://localhost:8100
 
-Fetching /capabilities
-Validating capabilities
-Fetching /schemaValidating schema
-Validating object_types
-Validating collections
-Validating collection articles
-Validating columns
-Validating collection authors
-Validating columns
-Validating collection articles_by_author
-Validating columns
-Validating functions
-Validating function latest_article_id
-Validating procedures
-Validating procedure upsert_article
-Testing /query
-Testing simple queries
-Querying collection articles
-Querying collection authors
-Skipping parameterized collection articles_by_author
-Testing aggregate queries
-Querying collection articles
-Querying collection authors
-Skipping parameterized collection articles_by_author
+Capabilities
+├ Fetching /capabilities ... ... OK
+├ Validating capabilities ... OK
+Schema
+├ Fetching /schema ... OK
+├ Validating schema ...
+│ ├ object_types ... OK
+│ ├ Collections ...
+│ │ ├ articles ...
+│ │ │ ├ Arguments ... OK
+│ │ │ ├ Collection type ... OK
+│ │ ├ authors ...
+│ │ │ ├ Arguments ... OK
+│ │ │ ├ Collection type ... OK
+│ │ ├ articles_by_author ...
+│ │ │ ├ Arguments ... OK
+│ │ │ ├ Collection type ... OK
+│ ├ Functions ...
+│ │ ├ latest_article_id ...
+│ │ │ ├ Result type ... OK
+│ │ │ ├ Arguments ... OK
+│ │ ├ Procedures ...
+│ │ │ ├ upsert_article ...
+│ │ │ │ ├ Result type ... OK
+│ │ │ │ ├ Arguments ... OK
+Query
+├ articles ...
+│ ├ Simple queries ...
+│ │ ├ Select top N ... OK
+│ │ ├ Predicates ... OK
+│ ├ Aggregate queries ...
+│ │ ├ star_count ... OK
+├ authors ...
+│ ├ Simple queries ...
+│ │ ├ Select top N ... OK
+│ │ ├ Predicates ... OK
+│ ├ Aggregate queries ...
+│ │ ├ star_count ... OK
+├ articles_by_author ...
 ```
 
 However, `ndc-test` cannot validate the entire schema. For example, it will not issue queries against the `articles_by_author` collection, because it does not have any way to synthesize inputs for its required collection argument.


### PR DESCRIPTION
- Adds some property-based tests which infer generators using the data returned by the query API.
- Removes the last vestige of column-level arguments (missed in the previous PR)
- Improves error reporting to use `Result` instead of `assert`/`panic`.