### PR TITLE
Support for filtering, aggregating and ordering by nested fields

### DIFF
--- a/ndc-client/src/lib.rs
+++ b/ndc-client/src/lib.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 extern crate serde_derive;
 
 extern crate serde;

--- a/ndc-client/src/lib.rs
+++ b/ndc-client/src/lib.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate serde_derive;
 
 extern crate serde;

--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -464,11 +464,11 @@ pub enum BinaryComparisonOperator {
 // ANCHOR_END: BinaryComparisonOperator
 
 // ANCHOR: ColumnSelector
-#[derive(Clone, Debug, PartialEq)]
 /// ColumnSelector consists of a column name (the first element) and possibly a 
 /// path to a field within a nested objects in that column.
 /// Multi-element ColumnSelectors are only valid for databases that support nested objects,
 /// e.g. MongoDB.
+#[derive(Clone, Debug, PartialEq)]
 pub struct ColumnSelector(pub Vec<String>);
 
 /// A string deserializes to a a single-element ColumnSelector.

--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -312,7 +312,7 @@ pub enum Aggregate {
     // TODO: do we need aggregation row limits?
     ColumnCount {
         /// The column to apply the count aggregate function to
-        column: ColumnSelector,
+        column: String,
         /// Whether or not only distinct items should be counted
         distinct: bool,
     },
@@ -463,9 +463,16 @@ pub enum BinaryComparisonOperator {
 }
 // ANCHOR_END: BinaryComparisonOperator
 
+// ANCHOR: ColumnSelector
 #[derive(Clone, Debug, PartialEq)]
+/// ColumnSelector consists of a column name (the first element) and possibly a 
+/// path to a field within a nested objects in that column.
+/// Multi-element ColumnSelectors are only valid for databases that support nested objects,
+/// e.g. MongoDB.
 pub struct ColumnSelector(pub Vec<String>);
 
+/// A string deserializes to a a single-element ColumnSelector.
+/// An array of strings deserializes to a multi-element ColumnSelector.
 impl<'de> Deserialize<'de> for ColumnSelector {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -500,6 +507,8 @@ impl<'de> Deserialize<'de> for ColumnSelector {
     }
 }
 
+/// A single-element ColumnSelector serlializes as a string.
+/// A multi-element ColumnSelector serializes as an array of strings.
 impl Serialize for ColumnSelector {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -512,6 +521,7 @@ impl Serialize for ColumnSelector {
     }
 }
 
+/// In JSON a ColumnSelector is either a string or an array of strings.
 impl JsonSchema for ColumnSelector {
     fn schema_name() -> String {
         "ColumnSelector".to_string()
@@ -531,6 +541,7 @@ impl JsonSchema for ColumnSelector {
         .into()
     }
 }
+// ANCHOR_END: ColumnSelector
 
 // ANCHOR: ComparisonTarget
 #[skip_serializing_none]

--- a/ndc-client/tests/json_schema/mutation_request.jsonschema
+++ b/ndc-client/tests/json_schema/mutation_request.jsonschema
@@ -43,7 +43,11 @@
           "properties": {
             "column": {
               "description": "The column to apply the count aggregate function to",
-              "type": "string"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ColumnSelector"
+                }
+              ]
             },
             "distinct": {
               "description": "Whether or not only distinct items should be counted",
@@ -67,7 +71,11 @@
           "properties": {
             "column": {
               "description": "The column to apply the aggregation function to",
-              "type": "string"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ColumnSelector"
+                }
+              ]
             },
             "function": {
               "description": "Single column aggregate function name.",
@@ -159,6 +167,19 @@
         }
       }
     },
+    "ColumnSelector": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "ComparisonTarget": {
       "oneOf": [
         {
@@ -171,7 +192,11 @@
           "properties": {
             "name": {
               "description": "The name of the column",
-              "type": "string"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ColumnSelector"
+                }
+              ]
             },
             "path": {
               "description": "Any relationships to traverse to reach this column",
@@ -197,7 +222,11 @@
           "properties": {
             "name": {
               "description": "The name of the column",
-              "type": "string"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ColumnSelector"
+                }
+              ]
             },
             "type": {
               "type": "string",
@@ -835,7 +864,11 @@
           "properties": {
             "name": {
               "description": "The name of the column",
-              "type": "string"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ColumnSelector"
+                }
+              ]
             },
             "path": {
               "description": "Any relationships to traverse to reach this column",
@@ -863,7 +896,11 @@
           "properties": {
             "column": {
               "description": "The column to apply the aggregation function to",
-              "type": "string"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ColumnSelector"
+                }
+              ]
             },
             "function": {
               "description": "Single column aggregate function name.",

--- a/ndc-client/tests/json_schema/mutation_request.jsonschema
+++ b/ndc-client/tests/json_schema/mutation_request.jsonschema
@@ -43,11 +43,7 @@
           "properties": {
             "column": {
               "description": "The column to apply the count aggregate function to",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/ColumnSelector"
-                }
-              ]
+              "type": "string"
             },
             "distinct": {
               "description": "Whether or not only distinct items should be counted",

--- a/ndc-client/tests/json_schema/query_request.jsonschema
+++ b/ndc-client/tests/json_schema/query_request.jsonschema
@@ -61,7 +61,11 @@
           "properties": {
             "column": {
               "description": "The column to apply the count aggregate function to",
-              "type": "string"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ColumnSelector"
+                }
+              ]
             },
             "distinct": {
               "description": "Whether or not only distinct items should be counted",
@@ -85,7 +89,11 @@
           "properties": {
             "column": {
               "description": "The column to apply the aggregation function to",
-              "type": "string"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ColumnSelector"
+                }
+              ]
             },
             "function": {
               "description": "Single column aggregate function name.",
@@ -197,6 +205,19 @@
         }
       ]
     },
+    "ColumnSelector": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "ComparisonTarget": {
       "oneOf": [
         {
@@ -209,7 +230,11 @@
           "properties": {
             "name": {
               "description": "The name of the column",
-              "type": "string"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ColumnSelector"
+                }
+              ]
             },
             "path": {
               "description": "Any relationships to traverse to reach this column",
@@ -235,7 +260,11 @@
           "properties": {
             "name": {
               "description": "The name of the column",
-              "type": "string"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ColumnSelector"
+                }
+              ]
             },
             "type": {
               "type": "string",
@@ -618,7 +647,11 @@
           "properties": {
             "name": {
               "description": "The name of the column",
-              "type": "string"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ColumnSelector"
+                }
+              ]
             },
             "path": {
               "description": "Any relationships to traverse to reach this column",
@@ -646,7 +679,11 @@
           "properties": {
             "column": {
               "description": "The column to apply the aggregation function to",
-              "type": "string"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ColumnSelector"
+                }
+              ]
             },
             "function": {
               "description": "Single column aggregate function name.",

--- a/ndc-client/tests/json_schema/query_request.jsonschema
+++ b/ndc-client/tests/json_schema/query_request.jsonschema
@@ -61,11 +61,7 @@
           "properties": {
             "column": {
               "description": "The column to apply the count aggregate function to",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/ColumnSelector"
-                }
-              ]
+              "type": "string"
             },
             "distinct": {
               "description": "Whether or not only distinct items should be counted",

--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -643,7 +643,7 @@ fn eval_aggregate(
             let values = paginated
                 .iter()
                 .map(|row| {
-                    select_from_row(row, column)
+                    row.get(column)
                         .ok_or((StatusCode::BAD_REQUEST, "invalid column name"))
                 })
                 .collect::<Result<Vec<_>, StatusLine>>()?;

--- a/specification/src/reference/types.md
+++ b/specification/src/reference/types.md
@@ -60,6 +60,12 @@
 {{#include ../../../ndc-client/src/models.rs:ComparisonOperatorDefinition}}
 ```
 
+## `ColumnSelector`
+
+```rust,no_run,noplayground
+{{#include ../../../ndc-client/src/models.rs:ColumnSelector}}
+```
+
 ## `ComparisonTarget`
 
 ```rust,no_run,noplayground

--- a/specification/src/specification/queries/aggregates.md
+++ b/specification/src/specification/queries/aggregates.md
@@ -41,7 +41,7 @@ In this case, the query has no predicate function, so all three aggregates would
 
 ## Aggregating on scalar fields in nested objects
 
-For databases that support nested objects (e.g. MongoDB), the `column` property of a `single_column` aggregate may be a [`ColumnSelector`](../../reference/types.md#orderbyelement) that specifies the path to a scalar field within an object-valued column.
+For databases that support nested objects (e.g. MongoDB), the `column` property of a `single_column` aggregate may be a [`ColumnSelector`](../../reference/types.md#columnselector) that specifies the path to a scalar field within an object-valued column.
 
 ## Requirements
 

--- a/specification/src/specification/queries/aggregates.md
+++ b/specification/src/specification/queries/aggregates.md
@@ -39,6 +39,10 @@ The following query object requests the aggregated sum of all order totals, alon
 
 In this case, the query has no predicate function, so all three aggregates would be computed over all rows.
 
+## Aggregating on scalar fields in nested objects
+
+For databases that support nested objects (e.g. MongoDB), the `column` property of a `single_column` aggregate may be a [`ColumnSelector`](../../reference/types.md#orderbyelement) that specifies the path to a scalar field within an object-valued column.
+
 ## Requirements
 
 - Each aggregate should be computed over all rows that match the `Query`.

--- a/specification/src/specification/queries/filtering.md
+++ b/specification/src/specification/queries/filtering.md
@@ -117,6 +117,8 @@ See type [`ComparisonValue`](../../reference/types.md#comparisonvalue) for the v
 
 Comparison operators compare columns to values. The column on the left hand side of any operator is described by a [`ComparisonTarget`](../../reference/types.md#comparisontarget), and the various cases will be explained next.
 
+The `name` property of `ComparisonTarget` is a [`ColumnSelector`](../../reference/types.md#orderbyelement), which can be either a string or an array of strings.  If it is a string or a singleton array then it refers to a scalar-valued top-level column. `ColumnSelector`s with multi-valued arrays are only relevant for databases that support nested objects, e.g. MongoDB. If `name` is a multi-value array then the first element refers to an object-valued top-level column and the remaining elements specify a path to a scalar-valued field within a nested object within that column.
+
 #### Referencing a column from the same collection
 
 If the `ComparisonTarget` has type `column`, and the `path` property is empty, then the `name` property refers to a column in the current collection.

--- a/specification/src/specification/queries/filtering.md
+++ b/specification/src/specification/queries/filtering.md
@@ -117,7 +117,7 @@ See type [`ComparisonValue`](../../reference/types.md#comparisonvalue) for the v
 
 Comparison operators compare columns to values. The column on the left hand side of any operator is described by a [`ComparisonTarget`](../../reference/types.md#comparisontarget), and the various cases will be explained next.
 
-The `name` property of `ComparisonTarget` is a [`ColumnSelector`](../../reference/types.md#orderbyelement), which can be either a string or an array of strings.  If it is a string or a singleton array then it refers to a scalar-valued top-level column. `ColumnSelector`s with multi-valued arrays are only relevant for databases that support nested objects, e.g. MongoDB. If `name` is a multi-value array then the first element refers to an object-valued top-level column and the remaining elements specify a path to a scalar-valued field within a nested object within that column.
+The `name` property of `ComparisonTarget` is a [`ColumnSelector`](../../reference/types.md#columnselector), which can be either a string or an array of strings.  If it is a string or a singleton array then it refers to a scalar-valued top-level column. `ColumnSelector`s with multi-valued arrays are only relevant for databases that support nested objects, e.g. MongoDB. If `name` is a multi-value array then the first element refers to an object-valued top-level column and the remaining elements specify a path to a scalar-valued field within a nested object within that column.
 
 #### Referencing a column from the same collection
 

--- a/specification/src/specification/queries/sorting.md
+++ b/specification/src/specification/queries/sorting.md
@@ -16,7 +16,7 @@ To compute the ordering from the `order_by` field, data connectors should implem
 
 ### Type `column`
 
-The field `element.target.name` is a [`ColumnSelector`](../../reference/types.md#orderbyelement), which can be either a string or an array of strings.  If it is a string or a singleton array then it refers to a scalar-valued top-level column. `ColumnSelector`s with multi-valued arrays are only relevant for databases that support nested objects, e.g. MongoDB. If `element.target.name` is a multi-value array then the first element refers to an object-valued top-level column and the remaining elements specify a path to a scalar-valued field within a nested object within that column.
+The field `element.target.name` is a [`ColumnSelector`](../../reference/types.md#columnselector), which can be either a string or an array of strings.  If it is a string or a singleton array then it refers to a scalar-valued top-level column. `ColumnSelector`s with multi-valued arrays are only relevant for databases that support nested objects, e.g. MongoDB. If `element.target.name` is a multi-value array then the first element refers to an object-valued top-level column and the remaining elements specify a path to a scalar-valued field within a nested object within that column.
 
 If `element.order_direction` is `asc`, then the row with the smaller column comes first. 
 
@@ -57,7 +57,7 @@ For example, this query sorts article authors by their total article count:
 
 ### Type `single_count_aggregate`
 
-The field `element.target.column` is a [`ColumnSelector`](../../reference/types.md#orderbyelement), which can be either a string or an array of strings.  If it is a string or a singleton array then it refers to a scalar-valued top-level column. `ColumnSelector`s with multi-valued arrays are only relevant for databases that support nested objects, e.g. MongoDB. If `element.target.column` is a multi-value array then the first element refers to an object-valued top-level column and the remaining elements specify a path to a scalar-valued field within a nested object within that column.
+The field `element.target.column` is a [`ColumnSelector`](../../reference/types.md#columnselector), which can be either a string or an array of strings.  If it is a string or a singleton array then it refers to a scalar-valued top-level column. `ColumnSelector`s with multi-valued arrays are only relevant for databases that support nested objects, e.g. MongoDB. If `element.target.column` is a multi-value array then the first element refers to an object-valued top-level column and the remaining elements specify a path to a scalar-valued field within a nested object within that column.
 
 An ordering of type `single_count_aggregate` orders rows by an aggregate computed over rows in some [related collection](./relationships.md). If the respective aggregates are incomparable, the ordering should continue to the next [`OrderByElement`](../../reference/types.md#orderbyelement).
 

--- a/specification/src/specification/queries/sorting.md
+++ b/specification/src/specification/queries/sorting.md
@@ -16,6 +16,8 @@ To compute the ordering from the `order_by` field, data connectors should implem
 
 ### Type `column`
 
+The field `element.target.name` is a [`ColumnSelector`](../../reference/types.md#orderbyelement), which can be either a string or an array of strings.  If it is a string or a singleton array then it refers to a scalar-valued top-level column. `ColumnSelector`s with multi-valued arrays are only relevant for databases that support nested objects, e.g. MongoDB. If `element.target.name` is a multi-value array then the first element refers to an object-valued top-level column and the remaining elements specify a path to a scalar-valued field within a nested object within that column.
+
 If `element.order_direction` is `asc`, then the row with the smaller column comes first. 
 
 If `element.order_direction` is `asc`, then the row with the smaller column comes second. 
@@ -54,6 +56,8 @@ For example, this query sorts article authors by their total article count:
 ```
 
 ### Type `single_count_aggregate`
+
+The field `element.target.column` is a [`ColumnSelector`](../../reference/types.md#orderbyelement), which can be either a string or an array of strings.  If it is a string or a singleton array then it refers to a scalar-valued top-level column. `ColumnSelector`s with multi-valued arrays are only relevant for databases that support nested objects, e.g. MongoDB. If `element.target.column` is a multi-value array then the first element refers to an object-valued top-level column and the remaining elements specify a path to a scalar-valued field within a nested object within that column.
 
 An ordering of type `single_count_aggregate` orders rows by an aggregate computed over rows in some [related collection](./relationships.md). If the respective aggregates are incomparable, the ordering should continue to the next [`OrderByElement`](../../reference/types.md#orderbyelement).
 


### PR DESCRIPTION
Modifies the ndc spec to allow referring to a nested field of an object-valued column when filtering aggregating and ordering. This is needed for databases that support nested objects, such as MongoDB.

We add a `ColumnSelector` type which is used instead of column names in `ComparisonTarget`, `Aggregate` and `OrderByTarget`. A `ColumnSelector` may refer to a single scalar column (represented by a JSON string) or to a path within an object-valued column (represented by an array of strings). 

This work is based on a similar change we made for the v2 DC API. See https://github.com/hasura/graphql-engine-mono/pull/9940 and https://github.com/hasura/graphql-engine-mono/pull/10082.