### PR TITLE
Procedure calling convention should match functions

### DIFF
--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -1499,12 +1499,17 @@ async fn execute_mutation_operation(
                                 );
                             }
                         }
-                        Ok(vec![row])
+                        Ok(row)
                     })
                     .transpose()?;
                 Ok(models::MutationOperationResults {
                     affected_rows: 1,
-                    returning,
+                    returning: Some(vec![IndexMap::from_iter([(
+                        "__value".into(),
+                        models::RowFieldValue(serde_json::to_value(returning).map_err(|_| {
+                            (StatusCode::INTERNAL_SERVER_ERROR, "cannot encode response")
+                        })?),
+                    )])]),
                 })
             }
             _ => Err((StatusCode::BAD_REQUEST, "unknown procedure")),

--- a/ndc-reference/tests/mutation/upsert_article/expected.json
+++ b/ndc-reference/tests/mutation/upsert_article/expected.json
@@ -1,13 +1,20 @@
 {
   "operation_results": [
     {
-      "affected_rows": 1
+      "affected_rows": 1,
+      "returning": [
+        {
+          "__value": null
+        }
+      ]
     },
     {
       "affected_rows": 1,
       "returning": [
         {
-          "id": 2
+          "__value": {
+            "id": 2
+          }
         }
       ]
     }

--- a/ndc-reference/tests/mutation/upsert_article_with_relationship/expected.json
+++ b/ndc-reference/tests/mutation/upsert_article_with_relationship/expected.json
@@ -4,14 +4,16 @@
       "affected_rows": 1,
       "returning": [
         {
-          "id": 2,
-          "author": {
-            "rows": [
-              {
-                "first_name": "John",
-                "last_name": "Hughes"
-              }
-            ]
+          "__value": {
+            "author": {
+              "rows": [
+                {
+                  "first_name": "John",
+                  "last_name": "Hughes"
+                }
+              ]
+            },
+            "id": 2
           }
         }
       ]


### PR DESCRIPTION
This does not include the specification yet, because the mutations section has not been written.

Later, it should include something like the following:

---

## Calling Convention

Procedures are invoked using the mutation endpoint, and return their response in the corresponding `MutationOperationResults` object.

Just like functions, procedures should return a single row and a single column, named `__value`, whose type is given by the procedure's return type.

As with functions, there is no need to define the wrapper type in the `object_types` section of the schema response.