### PR TITLE
Argument position

### DIFF
--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -212,6 +212,8 @@ pub struct ArgumentInfo {
     /// The name of the type of this argument
     #[serde(rename = "type")]
     pub argument_type: Type,
+    /// Zero-based index position of this argument in parameter list
+    pub argument_position: Option<u32>,
 }
 // ANCHOR_END: ArgumentInfo
 

--- a/ndc-client/tests/json_schema/schema_response.jsonschema
+++ b/ndc-client/tests/json_schema/schema_response.jsonschema
@@ -70,6 +70,15 @@
         "type"
       ],
       "properties": {
+        "argument_position": {
+          "description": "Zero-based index position of this argument in parameter list",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
         "description": {
           "description": "Argument description",
           "type": [

--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -347,6 +347,7 @@ async fn get_schema() -> Json<models::SchemaResponse> {
             models::ArgumentInfo {
                 argument_type: models::Type::Named { name: "Int".into() },
                 description: None,
+                argument_position: None,
             },
         )]),
         deletable: false,
@@ -374,6 +375,7 @@ async fn get_schema() -> Json<models::SchemaResponse> {
                 argument_type: models::Type::Named {
                     name: "article".into(),
                 },
+                argument_position: None,
             },
         )]),
         result_type: models::Type::Nullable {


### PR DESCRIPTION
Add optional argument position index to `ArgumentInfo`. This is for connectors that require arguments to be passed in a specific order, rather than by name.