### PR TITLE
Fix the non-deterministic version of IN

### DIFF
--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -1172,7 +1172,7 @@ fn eval_expression(
             values,
         } => match operator {
             models::BinaryArrayComparisonOperator::In => {
-                let left_val = eval_comparison_target(
+                let left_vals = eval_comparison_target(
                     collection_relationships,
                     variables,
                     state,
@@ -1181,17 +1181,21 @@ fn eval_expression(
                     item,
                 )?;
 
-                for v in values.iter() {
-                    let right_val = eval_comparison_value(
+                for comparison_value in values.iter() {
+                    let right_vals = eval_comparison_value(
                         collection_relationships,
                         variables,
                         state,
-                        v,
+                        comparison_value,
                         root,
                         item,
                     )?;
-                    if left_val == right_val {
-                        return Ok(true);
+                    for left_val in left_vals.iter() {
+                        for right_val in right_vals.iter() {
+                            if left_val == right_val {
+                                return Ok(true);
+                            }
+                        }
                     }
                 }
                 Ok(false)

--- a/ndc-reference/tests/query/predicate_with_in/expected.json
+++ b/ndc-reference/tests/query/predicate_with_in/expected.json
@@ -1,0 +1,18 @@
+[
+  {
+    "rows": [
+      {
+        "id": 1,
+        "title": "The Next 700 Programming Languages"
+      },
+      {
+        "id": 2,
+        "title": "Why Functional Programming Matters"
+      },
+      {
+        "id": 3,
+        "title": "The Design And Implementation Of Programming Languages"
+      }
+    ]
+  }
+]

--- a/ndc-reference/tests/query/predicate_with_in/request.json
+++ b/ndc-reference/tests/query/predicate_with_in/request.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "../../../../ndc-client/tests/json_schema/query_request.jsonschema",
+    "collection": "articles",
+    "arguments": {},
+    "query": {
+        "fields": {
+            "id": {
+                "type": "column",
+                "column": "id"
+            },
+            "title": {
+                "type": "column",
+                "column": "title"
+            }
+        },
+        "where": {
+            "type": "binary_array_comparison_operator",
+            "column": {
+                "type": "column",
+                "name": "author_id",
+                "path": []
+            },
+            "operator": "in",
+            "values": [
+                {
+                    "type": "scalar",
+                    "value": 1
+                },
+                {
+                    "type": "scalar",
+                    "value": 2
+                }
+            ]
+        }
+    },
+    "collection_relationships": {}
+}

--- a/ndc-reference/tests/query/predicate_with_nondet_in_1/expected.json
+++ b/ndc-reference/tests/query/predicate_with_nondet_in_1/expected.json
@@ -1,0 +1,16 @@
+[
+  {
+    "rows": [
+      {
+        "id": 1,
+        "first_name": "Peter",
+        "last_name": "Landin"
+      },
+      {
+        "id": 2,
+        "first_name": "John",
+        "last_name": "Hughes"
+      }
+    ]
+  }
+]

--- a/ndc-reference/tests/query/predicate_with_nondet_in_1/request.json
+++ b/ndc-reference/tests/query/predicate_with_nondet_in_1/request.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "../../../../ndc-client/tests/json_schema/query_request.jsonschema",
+    "collection": "authors",
+    "arguments": {},
+    "query": {
+        "fields": {
+            "id": {
+                "type": "column",
+                "column": "id"
+            },
+            "first_name": {
+                "type": "column",
+                "column": "first_name"
+            },
+            "last_name": {
+                "type": "column",
+                "column": "last_name"
+            }
+        },
+        "where": {
+            "type": "binary_array_comparison_operator",
+            "column": {
+                "type": "column",
+                "name": "title",
+                "path": [
+                    {
+                        "relationship": "author_articles",
+                        "arguments": {},
+                        "predicate": {
+                            "type": "and",
+                            "expressions": []
+                        }
+                    }
+                ]
+            },
+            "operator": "in",
+            "values": [
+                {
+                    "type": "scalar",
+                    "value": "The Next 700 Programming Languages"
+                },
+                {
+                    "type": "scalar",
+                    "value": "Why Functional Programming Matters"
+                }
+            ]
+        }
+    },
+    "collection_relationships": {
+        "author_articles": {
+            "arguments": {},
+            "column_mapping": {
+                "id": "author_id"
+            },
+            "relationship_type": "array",
+            "source_collection_or_type": "author",
+            "target_collection": "articles"
+        }
+    }
+}

--- a/ndc-reference/tests/query/predicate_with_nondet_in_2/expected.json
+++ b/ndc-reference/tests/query/predicate_with_nondet_in_2/expected.json
@@ -1,0 +1,14 @@
+[
+  {
+    "rows": [
+      {
+        "id": 1,
+        "title": "The Next 700 Programming Languages"
+      },
+      {
+        "id": 2,
+        "title": "Why Functional Programming Matters"
+      }
+    ]
+  }
+]

--- a/ndc-reference/tests/query/predicate_with_nondet_in_2/request.json
+++ b/ndc-reference/tests/query/predicate_with_nondet_in_2/request.json
@@ -1,0 +1,56 @@
+{
+    "$schema": "../../../../ndc-client/tests/json_schema/query_request.jsonschema",
+    "collection": "articles",
+    "arguments": {},
+    "query": {
+        "fields": {
+            "id": {
+                "type": "column",
+                "column": "id"
+            },
+            "title": {
+                "type": "column",
+                "column": "title"
+            }
+        },
+        "where": {
+            "type": "binary_array_comparison_operator",
+            "column": {
+                "type": "column",
+                "name": "id",
+                "path": []
+            },
+            "operator": "in",
+            "values": [
+                {
+                    "type": "column",
+                    "column": {
+                        "type": "column",
+                        "name": "id",
+                        "path": [
+                            {
+                                "relationship": "article_author",
+                                "arguments": {},
+                                "predicate": {
+                                    "type": "and",
+                                    "expressions": []
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "collection_relationships": {
+        "article_author": {
+            "arguments": {},
+            "column_mapping": {
+                "author_id": "id"
+            },
+            "relationship_type": "object",
+            "source_collection_or_type": "article",
+            "target_collection": "authors"
+        }
+    }
+}

--- a/specification/src/specification/queries/filtering.md
+++ b/specification/src/specification/queries/filtering.md
@@ -70,7 +70,7 @@ Binary comparison operators are denoted by expressions with a `type` field of `b
 
 See type [`ComparisonValue`](../../reference/types.md#comparisonvalue) for the valid inhabitants of the `value` field.
 
-_Note_: in general, `PathElement`s in a `ComparisonValue` can refer to _array_ relationships. However, in the case of the `in` operator, such requests can be very difficult to implement, and for practical purposes, it is not very useful to express such queries. Therefore, connectors can expect `PathElements` in `ComparisonValue`s to always only refer to _object_ relationships, and fail with a `Bad Request` error otherwise.
+_Note_: in general, `PathElement`s in a `ComparisonValue` can refer to _array_ relationships. However, in the case of the `in` operator, such requests can be very difficult to implement, and for practical purposes, it is not very useful to express such queries. Therefore, in the case of the `in` operator, connectors can expect `PathElements` in `ComparisonValue`s to always only refer to _object_ relationships, and fail with a `Bad Request` error otherwise.
 
 ```json
 {{#include ../../../../ndc-reference/tests/query/predicate_with_in/request.json:1 }}

--- a/specification/src/specification/queries/filtering.md
+++ b/specification/src/specification/queries/filtering.md
@@ -45,19 +45,8 @@ See type [`BinaryComparisonOperator`](../../reference/types.md#binarycomparisono
 See type [`ComparisonValue`](../../reference/types.md#comparisonvalue) for the valid inhabitants of the `value` field.
 
 ```json
-{
-    "type": "binary_comparison_operator",
-    "operator": {
-        "type": "equal"
-    },
-    "column": {
-        "name": "title"
-    },
-    "value": {
-        "type": "scalar",
-        "value": "The Next 700 Programming Languages"
-    }
-}
+{{#include ../../../../ndc-reference/tests/query/predicate_with_eq/request.json:1 }}
+{{#include ../../../../ndc-reference/tests/query/predicate_with_eq/request.json:3: }}
 ```
 
 ### Custom Binary Comparison Operators
@@ -67,20 +56,8 @@ Data connectors can also extend the expression grammar by defining comparison op
 For example, here is an expression which uses a custom `like` operator provided on the `String` type in the reference implementation:
 
 ```json
-{
-    "type": "binary_comparison_operator",
-    "operator": {
-        "type": "other",
-        "name": "like"
-    },
-    "column": {
-        "name": "title"
-    },
-    "value": {
-        "type": "scalar",
-        "value": "^.*Functional Programming.*$"
-    }
-}
+{{#include ../../../../ndc-reference/tests/query/predicate_with_like/request.json:1 }}
+{{#include ../../../../ndc-reference/tests/query/predicate_with_like/request.json:3: }}
 ```
 
 ### Binary Array-Valued Comparison Operators
@@ -93,24 +70,11 @@ Binary comparison operators are denoted by expressions with a `type` field of `b
 
 See type [`ComparisonValue`](../../reference/types.md#comparisonvalue) for the valid inhabitants of the `value` field.
 
+_Note_: in general, `PathElement`s in a `ComparisonValue` can refer to _array_ relationships. However, in the case of the `in` operator, such requests can be very difficult to implement, and for practical purposes, it is not very useful to express such queries. Therefore, connectors can expect `PathElements` in `ComparisonValue`s to always only refer to _object_ relationships, and fail with a `Bad Request` error otherwise.
+
 ```json
-{
-    "type": "binary_array_comparison_operator",
-    "operator": "in",
-    "column": {
-        "name": "id"
-    },
-    "values": [
-        {
-            "type": "scalar",
-            "value": "1"
-        },
-        {
-            "type": "scalar",
-            "value": "2"
-        }
-    ]
-}
+{{#include ../../../../ndc-reference/tests/query/predicate_with_in/request.json:1 }}
+{{#include ../../../../ndc-reference/tests/query/predicate_with_in/request.json:3: }}
 ```
 
 ### Columns in Operators


### PR DESCRIPTION
@BenoitRanque spotted an issue with the `IN` operator, which was mixing up two different uses of `Vec`: one to represent disjunctions across array relationships, and a second to represent arrays of values.

Both express disjunctions, so we can fix this by looping over all `Vec`s and looking for an equality match, which is nice and simple.

However, as @BenoitRanque points out, it's less simple for connectors which generate SQL or other query documents. There, we'd need to switch between `IN` and `ANY IN` as we look at different elements of the right hand side. For that reason, I've added a note to the specification which explicitly says that supporting non-deterministic right-hand-sides of `IN` is _not required_.