### PR TITLE
Use colored library in ndc-test, extract report into own function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "colored"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
+dependencies = [
+ "is-terminal",
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "console"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +989,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "clap",
+ "colored",
  "indexmap",
  "ndc-client",
  "proptest",

--- a/ndc-test/Cargo.toml
+++ b/ndc-test/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 [dependencies]
 async-trait = "^0.1.67"
 clap = { version = "^4", features = ["derive"] }
+colored = "2.0.4"
 indexmap = { version = "^1", features = ["serde"] }
 ndc-client = { path = "../ndc-client" }
 proptest = "^1.2.0"

--- a/ndc-test/src/main.rs
+++ b/ndc-test/src/main.rs
@@ -2,7 +2,7 @@ use std::process::exit;
 
 use clap::{Parser, Subcommand};
 use ndc_client::apis::configuration::Configuration;
-use ndc_test::TestConfiguration;
+use ndc_test::{TestConfiguration, report};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -42,21 +42,7 @@ async fn main() {
 
             if !results.failures.is_empty() {
                 println!();
-                println!(
-                    "\x1b[1;31mFailed with {0} test failures:\x1b[22;0m",
-                    results.failures.len()
-                );
-
-                let mut ix = 1;
-                for failure in results.failures {
-                    println!();
-                    println!("[{0}] {1}", ix, failure.name);
-                    for path_element in failure.path {
-                        println!("  in {0}", path_element);
-                    }
-                    println!("Details: {0}", failure.error);
-                    ix += 1;
-                }
+                println!("{}", report(results));
 
                 exit(1)
             }


### PR DESCRIPTION
@sordina This should make it possible to reduce code in hub, and turn off color manually if needed.