### PR TITLE
forward `headers` to connector

### DIFF
--- a/ndc-client/src/apis/configuration.rs
+++ b/ndc-client/src/apis/configuration.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use reqwest::header::HeaderMap;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {
@@ -9,7 +9,7 @@ pub struct Configuration {
     pub oauth_access_token: Option<String>,
     pub bearer_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
-    pub headers: Option<HashMap<String, String>>,
+    pub headers: Option<HeaderMap>,
 }
 
 pub type BasicAuth = (String, Option<String>);

--- a/ndc-client/src/apis/configuration.rs
+++ b/ndc-client/src/apis/configuration.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 #[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
@@ -7,6 +9,7 @@ pub struct Configuration {
     pub oauth_access_token: Option<String>,
     pub bearer_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
+    pub headers: Option<HashMap<String, String>>,
 }
 
 pub type BasicAuth = (String, Option<String>);

--- a/ndc-client/src/apis/default_api.rs
+++ b/ndc-client/src/apis/default_api.rs
@@ -61,10 +61,12 @@ pub async fn capabilities_get(
                     .header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
-            if let Some(ref headers) = &configuration.headers {
-                for (key, value) in headers {
-                    req_builder = req_builder.header(key, value.to_header_string());
-                }
+            if let Some(ref bearer_token) = configuration.bearer_access_token {
+                req_builder = req_builder.bearer_auth(bearer_token.as_str());
+            }
+            
+            if let Some(ref headers) = configuration.headers {
+                req_builder = req_builder.headers(headers.clone());
             }
 
             let req = req_builder.build()?;
@@ -115,10 +117,12 @@ pub async fn explain_post(
                     .header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
-            if let Some(ref headers) = &configuration.headers {
-                for (key, value) in headers {
-                    req_builder = req_builder.header(key, value.to_header_string());
-                }
+            if let Some(ref bearer_token) = configuration.bearer_access_token {
+                req_builder = req_builder.bearer_auth(bearer_token.as_str());
+            }
+
+            if let Some(ref headers) = configuration.headers {
+                req_builder = req_builder.headers(headers.clone());
             }
 
             req_builder = req_builder.json(&query_request);
@@ -173,10 +177,12 @@ pub async fn mutation_post(
                     .header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
-            if let Some(ref headers) = &configuration.headers {
-                for (key, value) in headers {
-                    req_builder = req_builder.header(key, value.to_header_string());
-                }
+            if let Some(ref bearer_token) = configuration.bearer_access_token {
+                req_builder = req_builder.bearer_auth(bearer_token.as_str());
+            }
+
+            if let Some(ref headers) = configuration.headers {
+                req_builder = req_builder.headers(headers.clone());
             }
 
             req_builder = req_builder.json(&mutation_request);
@@ -232,10 +238,12 @@ pub async fn query_post(
                         .header(reqwest::header::USER_AGENT, user_agent.clone());
                 }
 
-                if let Some(ref headers) = &configuration.headers {
-                    for (key, value) in headers {
-                        req_builder = req_builder.header(key, value.to_header_string());
-                    }
+                if let Some(ref bearer_token) = configuration.bearer_access_token {
+                    req_builder = req_builder.bearer_auth(bearer_token.as_str());
+                }
+    
+                if let Some(ref headers) = configuration.headers {
+                    req_builder = req_builder.headers(headers.clone());
                 }
 
                 req_builder = req_builder.json(&query_request);
@@ -289,10 +297,12 @@ pub async fn schema_get(
                     .header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
-            if let Some(ref headers) = &configuration.headers {
-                for (key, value) in headers {
-                    req_builder = req_builder.header(key, value.to_header_string());
-                }
+            if let Some(ref bearer_token) = configuration.bearer_access_token {
+                req_builder = req_builder.bearer_auth(bearer_token.as_str());
+            }
+
+            if let Some(ref headers) = configuration.headers {
+                req_builder = req_builder.headers(headers.clone());
             }
 
             let req = req_builder.build()?;

--- a/ndc-client/src/apis/default_api.rs
+++ b/ndc-client/src/apis/default_api.rs
@@ -61,8 +61,10 @@ pub async fn capabilities_get(
                     .header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
-            if let Some(ref bearer_token) = configuration.bearer_access_token {
-                req_builder = req_builder.bearer_auth(bearer_token.as_str());
+            if let Some(ref headers) = &configuration.headers {
+                for (key, value) in headers {
+                    req_builder = req_builder.header(key, value.to_header_string());
+                }
             }
 
             let req = req_builder.build()?;
@@ -113,8 +115,10 @@ pub async fn explain_post(
                     .header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
-            if let Some(ref bearer_token) = configuration.bearer_access_token {
-                req_builder = req_builder.bearer_auth(bearer_token.as_str());
+            if let Some(ref headers) = &configuration.headers {
+                for (key, value) in headers {
+                    req_builder = req_builder.header(key, value.to_header_string());
+                }
             }
 
             req_builder = req_builder.json(&query_request);
@@ -169,8 +173,10 @@ pub async fn mutation_post(
                     .header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
-            if let Some(ref bearer_token) = configuration.bearer_access_token {
-                req_builder = req_builder.bearer_auth(bearer_token.as_str());
+            if let Some(ref headers) = &configuration.headers {
+                for (key, value) in headers {
+                    req_builder = req_builder.header(key, value.to_header_string());
+                }
             }
 
             req_builder = req_builder.json(&mutation_request);
@@ -226,8 +232,10 @@ pub async fn query_post(
                         .header(reqwest::header::USER_AGENT, user_agent.clone());
                 }
 
-                if let Some(ref bearer_token) = configuration.bearer_access_token {
-                    req_builder = req_builder.bearer_auth(bearer_token.as_str());
+                if let Some(ref headers) = &configuration.headers {
+                    for (key, value) in headers {
+                        req_builder = req_builder.header(key, value.to_header_string());
+                    }
                 }
 
                 req_builder = req_builder.json(&query_request);
@@ -281,8 +289,10 @@ pub async fn schema_get(
                     .header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
-            if let Some(ref bearer_token) = configuration.bearer_access_token {
-                req_builder = req_builder.bearer_auth(bearer_token.as_str());
+            if let Some(ref headers) = &configuration.headers {
+                for (key, value) in headers {
+                    req_builder = req_builder.header(key, value.to_header_string());
+                }
             }
 
             let req = req_builder.build()?;

--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -801,7 +801,7 @@ pub struct MutationOperationResults {
 }
 // ANCHOR_END: MutationOperationResults
 
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 #[schemars(title = "SecretOrLiteral")]
 /// Either a literal string or a reference to a Hasura secret

--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -801,7 +801,7 @@ pub struct MutationOperationResults {
 }
 // ANCHOR_END: MutationOperationResults
 
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
 #[serde(untagged)]
 #[schemars(title = "SecretOrLiteral")]
 /// Either a literal string or a reference to a Hasura secret

--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -801,7 +801,7 @@ pub struct MutationOperationResults {
 }
 // ANCHOR_END: MutationOperationResults
 
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq, Clone)]
 #[serde(untagged)]
 #[schemars(title = "SecretOrLiteral")]
 /// Either a literal string or a reference to a Hasura secret

--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -801,7 +801,7 @@ pub struct MutationOperationResults {
 }
 // ANCHOR_END: MutationOperationResults
 
-#[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
 #[serde(untagged)]
 #[schemars(title = "SecretOrLiteral")]
 /// Either a literal string or a reference to a Hasura secret

--- a/ndc-test/src/main.rs
+++ b/ndc-test/src/main.rs
@@ -36,6 +36,7 @@ async fn main() {
                 oauth_access_token: None,
                 bearer_access_token: None,
                 api_key: None,
+                headers: None,
             };
 
             let results = ndc_test::test_connector(&test_configuration, &configuration).await;


### PR DESCRIPTION
This PR extends struct `Configuration` to include a new optional field `headers`.
These headers are simply forwarded to the data connectors while building request.