### PR TITLE
Inline versions and editions in Cargo.toml files.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,4 @@
 [workspace]
-package.version = "0.1.0"
-package.edition = "2021"
-
 members = [
   "ndc-client",
   "ndc-reference",

--- a/ndc-client/Cargo.toml
+++ b/ndc-client/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ndc-client"
 description = "Protocol definitions and client library for the Hasura NDC specification"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 async-trait = "^0.1.67"

--- a/ndc-reference/Cargo.toml
+++ b/ndc-reference/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ndc-reference"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [[bin]]
 name = "ndc-reference"

--- a/ndc-test/Cargo.toml
+++ b/ndc-test/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ndc-test"
 description = "A tool to verify that a data connector is somewhat compatible with the specification"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 async-trait = "^0.1.67"


### PR DESCRIPTION
Unfortunately, [Crane][], which we use for Nix builds, does not seem to handle these well when dealing with Git dependencies.

For now, we will just duplicate the values.

[Crane]: https://github.com/ipetkov/crane