### PR TITLE
use empty object instead of json value for leaf capabilities

### DIFF
--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -32,7 +32,7 @@ pub struct CapabilitiesResponse {
 /// This is an empty struct to allow for future sub-capabilities.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct LeafCapability {}
-// ANCHOR_END: Capabilities
+// ANCHOR_END: LeafCapability
 
 // ANCHOR: Capabilities
 /// Describes the features of the specification which a data connector implements.

--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -27,6 +27,13 @@ pub struct CapabilitiesResponse {
 }
 // ANCHOR_END: CapabilitiesResponse
 
+// ANCHOR: LeafCapability
+/// A unit value to indicate a particular leaf capability is supported.
+/// This is an empty struct to allow for future sub-capabilities.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct LeafCapability {}
+// ANCHOR_END: Capabilities
+
 // ANCHOR: Capabilities
 /// Describes the features of the specification which a data connector implements.
 #[skip_serializing_none]
@@ -34,9 +41,9 @@ pub struct CapabilitiesResponse {
 #[schemars(title = "Capabilities")]
 pub struct Capabilities {
     pub query: Option<QueryCapabilities>,
-    pub explain: Option<serde_json::Value>,
+    pub explain: Option<LeafCapability>,
     pub mutations: Option<MutationCapabilities>,
-    pub relationships: Option<serde_json::Value>,
+    pub relationships: Option<LeafCapability>,
 }
 // ANCHOR_END: Capabilities
 
@@ -46,11 +53,11 @@ pub struct Capabilities {
 #[schemars(title = "Query Capabilities")]
 pub struct QueryCapabilities {
     /// Does the agent support comparisons that involve related collections (ie. joins)?
-    pub relation_comparisons: Option<serde_json::Value>,
+    pub relation_comparisons: Option<LeafCapability>,
     /// Does the agent support ordering by an aggregated array relationship?
-    pub order_by_aggregate: Option<serde_json::Value>,
+    pub order_by_aggregate: Option<LeafCapability>,
     /// Does the agent support foreach queries, i.e. queries with variables
-    pub foreach: Option<serde_json::Value>,
+    pub foreach: Option<LeafCapability>,
 }
 // ANCHOR_END: QueryCapabilities
 
@@ -60,8 +67,8 @@ pub struct QueryCapabilities {
 #[schemars(title = "Mutation Capabilities")]
 pub struct MutationCapabilities {
     /// Whether or not nested inserts to related collections are supported
-    pub nested_inserts: Option<serde_json::Value>,
-    pub returning: Option<serde_json::Value>,
+    pub nested_inserts: Option<LeafCapability>,
+    pub returning: Option<LeafCapability>,
 }
 // ANCHOR_END: MutationCapabilities
 

--- a/ndc-client/tests/json_schema/capabilities_response.jsonschema
+++ b/ndc-client/tests/json_schema/capabilities_response.jsonschema
@@ -30,7 +30,16 @@
             }
           ]
         },
-        "explain": true,
+        "explain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "mutations": {
           "anyOf": [
             {
@@ -41,7 +50,16 @@
             }
           ]
         },
-        "relationships": true
+        "relationships": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
       }
     },
     "QueryCapabilities": {
@@ -49,24 +67,69 @@
       "type": "object",
       "properties": {
         "relation_comparisons": {
-          "description": "Does the agent support comparisons that involve related collections (ie. joins)?"
+          "description": "Does the agent support comparisons that involve related collections (ie. joins)?",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "order_by_aggregate": {
-          "description": "Does the agent support ordering by an aggregated array relationship?"
+          "description": "Does the agent support ordering by an aggregated array relationship?",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "foreach": {
-          "description": "Does the agent support foreach queries, i.e. queries with variables"
+          "description": "Does the agent support foreach queries, i.e. queries with variables",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
+    },
+    "LeafCapability": {
+      "description": "A unit value to indicate a particular leaf capability is supported. This is an empty struct to allow for future sub-capabilities.",
+      "type": "object"
     },
     "MutationCapabilities": {
       "title": "Mutation Capabilities",
       "type": "object",
       "properties": {
         "nested_inserts": {
-          "description": "Whether or not nested inserts to related collections are supported"
+          "description": "Whether or not nested inserts to related collections are supported",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
-        "returning": true
+        "returning": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
       }
     }
   }

--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -13,7 +13,7 @@ use axum::{
 };
 
 use indexmap::IndexMap;
-use ndc_client::models;
+use ndc_client::models::{self, LeafCapability};
 use prometheus::{Encoder, IntCounter, IntGauge, Opts, Registry, TextEncoder};
 use regex::Regex;
 use tokio::sync::Mutex;
@@ -161,21 +161,20 @@ async fn get_metrics(State(state): State<Arc<Mutex<AppState>>>) -> Result<String
 // ANCHOR_END: metrics
 // ANCHOR: capabilities
 async fn get_capabilities() -> Json<models::CapabilitiesResponse> {
-    let empty = serde_json::to_value(BTreeMap::<String, ()>::new()).unwrap();
     Json(models::CapabilitiesResponse {
         versions: "^0.1.0".into(),
         capabilities: models::Capabilities {
             explain: None,
             query: Some(models::QueryCapabilities {
-                foreach: Some(empty.clone()),
-                order_by_aggregate: Some(empty.clone()),
-                relation_comparisons: Some(empty.clone()),
+                foreach: Some(LeafCapability {}),
+                order_by_aggregate: Some(LeafCapability {}),
+                relation_comparisons: Some(LeafCapability {}),
             }),
             mutations: Some(models::MutationCapabilities {
-                returning: Some(empty.clone()),
-                nested_inserts: Some(empty.clone()),
+                returning: Some(LeafCapability {}),
+                nested_inserts: Some(LeafCapability {}),
             }),
-            relationships: Some(empty),
+            relationships: Some(LeafCapability {}),
         },
     })
 }
@@ -1725,7 +1724,7 @@ mod tests {
     };
     use tokio::sync::Mutex;
 
-    use crate::{get_capabilities, get_schema, init_app_state, post_query, post_mutation};
+    use crate::{get_capabilities, get_schema, init_app_state, post_mutation, post_query};
 
     #[test]
     fn test_capabilities() {

--- a/specification/src/reference/types.md
+++ b/specification/src/reference/types.md
@@ -48,12 +48,6 @@
 {{#include ../../../ndc-client/src/models.rs:CapabilitiesResponse}}
 ```
 
-## `ProcedureInfo`
-
-```rust,no_run,noplayground
-{{#include ../../../ndc-client/src/models.rs:ProcedureInfo}}
-```
-
 ## `ComparisonOperatorDefinition`
 
 ```rust,no_run,noplayground
@@ -118,6 +112,12 @@
 
 ```rust,no_run,noplayground
 {{#include ../../../ndc-client/src/models.rs:InsertFieldSchema}}
+```
+
+## `LeafCapability`
+
+```rust,no_run,noplayground
+{{#include ../../../ndc-client/src/models.rs:LeafCapability}}
 ```
 
 ## `MutationCapabilities`
@@ -196,6 +196,12 @@
 
 ```rust,no_run,noplayground
 {{#include ../../../ndc-client/src/models.rs:PathElement}}
+```
+
+## `ProcedureInfo`
+
+```rust,no_run,noplayground
+{{#include ../../../ndc-client/src/models.rs:ProcedureInfo}}
 ```
 
 ## `Query`


### PR DESCRIPTION
This conveys the intent of the field more clearly and also avoids accepting non-object values