### PR TITLE
remove auth and other headers from api configuration

### DIFF
--- a/ndc-client/src/apis/configuration.rs
+++ b/ndc-client/src/apis/configuration.rs
@@ -1,3 +1,5 @@
+use reqwest::header::{HeaderMap, HeaderValue};
+
 #[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
@@ -6,6 +8,8 @@ pub struct Configuration {
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub bearer_access_token: Option<String>,
+    // TODO: should we remove other access tokens and basic_auth?
+    pub headers: HeaderMap<HeaderValue>,
     pub api_key: Option<ApiKey>,
 }
 

--- a/ndc-client/src/apis/configuration.rs
+++ b/ndc-client/src/apis/configuration.rs
@@ -1,4 +1,4 @@
-/// Configuration for the API.
+/// Configuration for the API client
 /// Contains all the information necessary to perform requests.
 /// 
 /// Please note that there is no headers field, headers (for authentication and custom headers) are supposed to be added
@@ -37,13 +37,4 @@ pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
     pub client: reqwest::Client,
-    pub api_key: Option<ApiKey>,
-}
-
-pub type BasicAuth = (String, Option<String>);
-
-#[derive(Debug, Clone)]
-pub struct ApiKey {
-    pub prefix: Option<String>,
-    pub key: String,
 }

--- a/ndc-client/src/apis/configuration.rs
+++ b/ndc-client/src/apis/configuration.rs
@@ -1,11 +1,42 @@
-use reqwest::header::{HeaderMap, HeaderValue};
-
+/// Configuration for the API.
+/// Contains all the information necessary to perform requests.
+/// 
+/// Please note that there is no headers field, headers (for authentication and custom headers) are supposed to be added
+/// as default headers in the `reqwest::Client` itself.
+/// 
+/// # Example
+/// 
+/// ```rs
+/// use ndc_client::apis::configuration::Configuration;
+/// 
+/// let mut headers = HeaderMap::new();
+/// headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer ..."));
+/// headers.insert(HeaderName::from_static("x-header"), HeaderValue::from_static("..."));
+/// 
+/// let client_builder = ClientBuilder::new().default_headers(headers);
+/// let client = client_builder.build().unwrap(); // handle errors elegantly in your app
+/// 
+/// let configuration = Configuration {
+///    base_path: "https://api.example.com".to_owned(),
+///    user_agent: Some("GraphQL-Engine/3.0.0/rust".to_owned()),
+///    client,
+///    api_key: Some(SECRET_KEY.to_owned()),
+/// };
+/// ```
+/// 
+/// Now this configuration can be used to perform some API requests.
+/// 
+/// ```rs
+/// use ndc_client::apis::configuration::default_api::schema_get;
+/// 
+/// let schema_response = schema_get(&configuration).await;
+/// ```
+/// 
 #[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
     pub client: reqwest::Client,
-    pub headers: HeaderMap<HeaderValue>,
     pub api_key: Option<ApiKey>,
 }
 

--- a/ndc-client/src/apis/configuration.rs
+++ b/ndc-client/src/apis/configuration.rs
@@ -5,9 +5,6 @@ pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
     pub client: reqwest::Client,
-    pub basic_auth: Option<BasicAuth>,
-    pub oauth_access_token: Option<String>,
-    // TODO: should we remove oauth access tokens and basic_auth as well?
     pub headers: HeaderMap<HeaderValue>,
     pub api_key: Option<ApiKey>,
 }

--- a/ndc-client/src/apis/configuration.rs
+++ b/ndc-client/src/apis/configuration.rs
@@ -7,8 +7,7 @@ pub struct Configuration {
     pub client: reqwest::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
-    pub bearer_access_token: Option<String>,
-    // TODO: should we remove other access tokens and basic_auth?
+    // TODO: should we remove oauth access tokens and basic_auth as well?
     pub headers: HeaderMap<HeaderValue>,
     pub api_key: Option<ApiKey>,
 }

--- a/ndc-client/src/apis/default_api.rs
+++ b/ndc-client/src/apis/default_api.rs
@@ -61,8 +61,6 @@ pub async fn capabilities_get(
                     .header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
-            // Note: The headers will be merged in to any already set.
-            req_builder = req_builder.headers(configuration.headers.clone());
 
             let req = req_builder.build()?;
             let resp = client
@@ -112,8 +110,6 @@ pub async fn explain_post(
                     .header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
-            // Note: The headers will be merged in to any already set.
-            req_builder = req_builder.headers(configuration.headers.clone());
 
             req_builder = req_builder.json(&query_request);
 
@@ -167,8 +163,6 @@ pub async fn mutation_post(
                     .header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
-            // Note: The headers will be merged in to any already set.
-            req_builder = req_builder.headers(configuration.headers.clone());
 
             req_builder = req_builder.json(&mutation_request);
 
@@ -223,8 +217,6 @@ pub async fn query_post(
                         .header(reqwest::header::USER_AGENT, user_agent.clone());
                 }
 
-                // Note: The headers will be merged in to any already set.
-                req_builder = req_builder.headers(configuration.headers.clone());
 
                 req_builder = req_builder.json(&query_request);
 
@@ -277,8 +269,6 @@ pub async fn schema_get(
                     .header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
-            // Note: The headers will be merged in to any already set.
-            req_builder = req_builder.headers(configuration.headers.clone());
 
             let req = req_builder.build()?;
             let resp = client

--- a/ndc-client/src/apis/default_api.rs
+++ b/ndc-client/src/apis/default_api.rs
@@ -64,6 +64,8 @@ pub async fn capabilities_get(
             if let Some(ref bearer_token) = configuration.bearer_access_token {
                 req_builder = req_builder.bearer_auth(bearer_token.as_str());
             }
+            // Note: The headers will be merged in to any already set.
+            req_builder = req_builder.headers(configuration.headers.clone());
 
             let req = req_builder.build()?;
             let resp = client
@@ -116,6 +118,8 @@ pub async fn explain_post(
             if let Some(ref bearer_token) = configuration.bearer_access_token {
                 req_builder = req_builder.bearer_auth(bearer_token.as_str());
             }
+            // Note: The headers will be merged in to any already set.
+            req_builder = req_builder.headers(configuration.headers.clone());
 
             req_builder = req_builder.json(&query_request);
 
@@ -172,6 +176,8 @@ pub async fn mutation_post(
             if let Some(ref bearer_token) = configuration.bearer_access_token {
                 req_builder = req_builder.bearer_auth(bearer_token.as_str());
             }
+            // Note: The headers will be merged in to any already set.
+            req_builder = req_builder.headers(configuration.headers.clone());
 
             req_builder = req_builder.json(&mutation_request);
 
@@ -229,6 +235,8 @@ pub async fn query_post(
                 if let Some(ref bearer_token) = configuration.bearer_access_token {
                     req_builder = req_builder.bearer_auth(bearer_token.as_str());
                 }
+                // Note: The headers will be merged in to any already set.
+                req_builder = req_builder.headers(configuration.headers.clone());
 
                 req_builder = req_builder.json(&query_request);
 
@@ -284,6 +292,8 @@ pub async fn schema_get(
             if let Some(ref bearer_token) = configuration.bearer_access_token {
                 req_builder = req_builder.bearer_auth(bearer_token.as_str());
             }
+            // Note: The headers will be merged in to any already set.
+            req_builder = req_builder.headers(configuration.headers.clone());
 
             let req = req_builder.build()?;
             let resp = client

--- a/ndc-client/src/apis/default_api.rs
+++ b/ndc-client/src/apis/default_api.rs
@@ -61,9 +61,6 @@ pub async fn capabilities_get(
                     .header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
-            if let Some(ref bearer_token) = configuration.bearer_access_token {
-                req_builder = req_builder.bearer_auth(bearer_token.as_str());
-            }
             // Note: The headers will be merged in to any already set.
             req_builder = req_builder.headers(configuration.headers.clone());
 
@@ -115,9 +112,6 @@ pub async fn explain_post(
                     .header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
-            if let Some(ref bearer_token) = configuration.bearer_access_token {
-                req_builder = req_builder.bearer_auth(bearer_token.as_str());
-            }
             // Note: The headers will be merged in to any already set.
             req_builder = req_builder.headers(configuration.headers.clone());
 
@@ -173,9 +167,6 @@ pub async fn mutation_post(
                     .header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
-            if let Some(ref bearer_token) = configuration.bearer_access_token {
-                req_builder = req_builder.bearer_auth(bearer_token.as_str());
-            }
             // Note: The headers will be merged in to any already set.
             req_builder = req_builder.headers(configuration.headers.clone());
 
@@ -232,9 +223,6 @@ pub async fn query_post(
                         .header(reqwest::header::USER_AGENT, user_agent.clone());
                 }
 
-                if let Some(ref bearer_token) = configuration.bearer_access_token {
-                    req_builder = req_builder.bearer_auth(bearer_token.as_str());
-                }
                 // Note: The headers will be merged in to any already set.
                 req_builder = req_builder.headers(configuration.headers.clone());
 
@@ -289,9 +277,6 @@ pub async fn schema_get(
                     .header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
-            if let Some(ref bearer_token) = configuration.bearer_access_token {
-                req_builder = req_builder.bearer_auth(bearer_token.as_str());
-            }
             // Note: The headers will be merged in to any already set.
             req_builder = req_builder.headers(configuration.headers.clone());
 

--- a/ndc-test/src/main.rs
+++ b/ndc-test/src/main.rs
@@ -47,7 +47,6 @@ async fn main() {
                 base_path: endpoint,
                 user_agent: None,
                 client: reqwest::Client::new(),
-                api_key: None,
             };
 
             let results = ndc_test::test_connector(&test_configuration, &configuration).await;
@@ -67,7 +66,6 @@ async fn main() {
                 base_path: endpoint,
                 user_agent: None,
                 client: reqwest::Client::new(),
-                api_key: None,
             };
 
             let results = ndc_test::test_snapshots_in_directory(&configuration, snapshots_dir).await;

--- a/ndc-test/src/main.rs
+++ b/ndc-test/src/main.rs
@@ -3,6 +3,7 @@ use std::{path::PathBuf, process::exit};
 use clap::{Parser, Subcommand};
 use ndc_client::apis::configuration::Configuration;
 use ndc_test::{report, TestConfiguration};
+use reqwest::header::HeaderMap;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -50,6 +51,7 @@ async fn main() {
                 basic_auth: None,
                 oauth_access_token: None,
                 bearer_access_token: None,
+                headers: HeaderMap::new(),
                 api_key: None,
             };
 
@@ -73,6 +75,7 @@ async fn main() {
                 basic_auth: None,
                 oauth_access_token: None,
                 bearer_access_token: None,
+                headers: HeaderMap::new(),
                 api_key: None,
             };
 

--- a/ndc-test/src/main.rs
+++ b/ndc-test/src/main.rs
@@ -50,7 +50,6 @@ async fn main() {
                 client: reqwest::Client::new(),
                 basic_auth: None,
                 oauth_access_token: None,
-                bearer_access_token: None,
                 headers: HeaderMap::new(),
                 api_key: None,
             };
@@ -74,7 +73,6 @@ async fn main() {
                 client: reqwest::Client::new(),
                 basic_auth: None,
                 oauth_access_token: None,
-                bearer_access_token: None,
                 headers: HeaderMap::new(),
                 api_key: None,
             };

--- a/ndc-test/src/main.rs
+++ b/ndc-test/src/main.rs
@@ -48,8 +48,6 @@ async fn main() {
                 base_path: endpoint,
                 user_agent: None,
                 client: reqwest::Client::new(),
-                basic_auth: None,
-                oauth_access_token: None,
                 headers: HeaderMap::new(),
                 api_key: None,
             };
@@ -71,8 +69,6 @@ async fn main() {
                 base_path: endpoint,
                 user_agent: None,
                 client: reqwest::Client::new(),
-                basic_auth: None,
-                oauth_access_token: None,
                 headers: HeaderMap::new(),
                 api_key: None,
             };

--- a/ndc-test/src/main.rs
+++ b/ndc-test/src/main.rs
@@ -3,7 +3,6 @@ use std::{path::PathBuf, process::exit};
 use clap::{Parser, Subcommand};
 use ndc_client::apis::configuration::Configuration;
 use ndc_test::{report, TestConfiguration};
-use reqwest::header::HeaderMap;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -48,7 +47,6 @@ async fn main() {
                 base_path: endpoint,
                 user_agent: None,
                 client: reqwest::Client::new(),
-                headers: HeaderMap::new(),
                 api_key: None,
             };
 
@@ -69,7 +67,6 @@ async fn main() {
                 base_path: endpoint,
                 user_agent: None,
                 client: reqwest::Client::new(),
-                headers: HeaderMap::new(),
                 api_key: None,
             };
 


### PR DESCRIPTION
This PR removes auth and other headers from the API Configuration struct. This PR also adds some documentation around how we can add headers to be sent in API requests.