### PR TITLE
add headers in `Configuration`

### DIFF
--- a/ndc-client/src/apis/configuration.rs
+++ b/ndc-client/src/apis/configuration.rs
@@ -1,40 +1,10 @@
+use reqwest::header::{HeaderMap, HeaderValue};
 /// Configuration for the API client
 /// Contains all the information necessary to perform requests.
-/// 
-/// Please note that there is no headers field, headers (for authentication and custom headers) are supposed to be added
-/// as default headers in the `reqwest::Client` itself.
-/// 
-/// # Example
-/// 
-/// ```rs
-/// use ndc_client::apis::configuration::Configuration;
-/// 
-/// let mut headers = HeaderMap::new();
-/// headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer ..."));
-/// headers.insert(HeaderName::from_static("x-header"), HeaderValue::from_static("..."));
-/// 
-/// let client_builder = ClientBuilder::new().default_headers(headers);
-/// let client = client_builder.build().unwrap(); // handle errors elegantly in your app
-/// 
-/// let configuration = Configuration {
-///    base_path: "https://api.example.com".to_owned(),
-///    user_agent: Some("GraphQL-Engine/3.0.0/rust".to_owned()),
-///    client,
-///    api_key: Some(SECRET_KEY.to_owned()),
-/// };
-/// ```
-/// 
-/// Now this configuration can be used to perform some API requests.
-/// 
-/// ```rs
-/// use ndc_client::apis::configuration::default_api::schema_get;
-/// 
-/// let schema_response = schema_get(&configuration).await;
-/// ```
-/// 
 #[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
     pub client: reqwest::Client,
+    pub headers: HeaderMap<HeaderValue>,
 }

--- a/ndc-client/src/apis/default_api.rs
+++ b/ndc-client/src/apis/default_api.rs
@@ -59,6 +59,8 @@ pub async fn capabilities_get(
                 req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
+            // Note: The headers will be merged in to any already set.
+            req_builder = req_builder.headers(configuration.headers.clone());
 
             let req = req_builder.build()?;
             let resp = client.execute(req).with_traced_errors().await?;
@@ -99,6 +101,8 @@ pub async fn explain_post(
                 req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
+            // Note: The headers will be merged in to any already set.
+            req_builder = req_builder.headers(configuration.headers.clone());
 
             req_builder = req_builder.json(&query_request);
 
@@ -143,6 +147,8 @@ pub async fn mutation_post(
                 req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
+            // Note: The headers will be merged in to any already set.
+            req_builder = req_builder.headers(configuration.headers.clone());
 
             req_builder = req_builder.json(&mutation_request);
 
@@ -189,6 +195,8 @@ pub async fn query_post(
                         req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
                 }
 
+                // Note: The headers will be merged in to any already set.
+                req_builder = req_builder.headers(configuration.headers.clone());
 
                 req_builder = req_builder.json(&query_request);
 
@@ -236,6 +244,8 @@ pub async fn schema_get(
                 req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
             }
 
+            // Note: The headers will be merged in to any already set.
+            req_builder = req_builder.headers(configuration.headers.clone());
 
             let req = req_builder.build()?;
             let resp = client.execute(req).with_traced_errors().await?;

--- a/ndc-test/src/lib.rs
+++ b/ndc-test/src/lib.rs
@@ -803,7 +803,6 @@ async fn select_top_n_using_foreign_key<C: Connector>(
                 models::Relationship {
                     column_mapping: foreign_key.column_mapping.clone(),
                     relationship_type: models::RelationshipType::Object,
-                    source_collection_or_type: "".into(),
                     target_collection: foreign_key.foreign_collection.clone(),
                     arguments: BTreeMap::new(),
                 },
@@ -888,7 +887,6 @@ async fn select_top_n_using_foreign_key_as_array_relationship<C: Connector>(
                 models::Relationship {
                     column_mapping,
                     relationship_type: models::RelationshipType::Array,
-                    source_collection_or_type: "".into(),
                     target_collection: collection_info.name.clone(),
                     arguments: BTreeMap::new(),
                 },

--- a/ndc-test/src/main.rs
+++ b/ndc-test/src/main.rs
@@ -3,6 +3,7 @@ use std::{path::PathBuf, process::exit};
 use clap::{Parser, Subcommand};
 use ndc_client::apis::configuration::Configuration;
 use ndc_test::{report, TestConfiguration};
+use reqwest::header::HeaderMap;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -47,6 +48,7 @@ async fn main() {
                 base_path: endpoint,
                 user_agent: None,
                 client: reqwest::Client::new(),
+                headers: HeaderMap::new(),
             };
 
             let results = ndc_test::test_connector(&test_configuration, &configuration).await;
@@ -66,6 +68,7 @@ async fn main() {
                 base_path: endpoint,
                 user_agent: None,
                 client: reqwest::Client::new(),
+                headers: HeaderMap::new(),
             };
 
             let results =


### PR DESCRIPTION
This PR adds `headers` in `Configuration`.

We can add headers in the `reqwest::Client` as well, but there is no direct function to mutate `Client` and add headers. To set headers in the client, we need to create a new client, something like this:
```rust
let mut headers = HeaderMap::new();
headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer ..."));
headers.insert(HeaderName::from_static("x-header"), HeaderValue::from_static("..."));

let client_builder = ClientBuilder::new().default_headers(headers);
let client = client_builder.build().unwrap(); // handle errors elegantly in your app
```

Now, for a situation where the headers may change between each request, we can do either of the following:
1. Initialize `Client` for each data connector and store them in memory. This means a significant hit on the memory consumption.
2. Initialize `Client` on each request. This means a significant hit on the performance.

That is why we have decided to add headers to the `Configuration` itself.