### PR TITLE
Revisions to initial capabilities structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ cargo build
 cargo test
 ```
 
-### Run the reference agent
+### Run the reference connector
 
 ```sh
 (cd ndc-reference; cargo run)
@@ -25,13 +25,13 @@ docker build -t reference_connector .
 docker run -it --rm -p 8100:8100 reference_connector
 ```
 
-The reference agent runs on http://localhost:8100:
+The reference connector runs on http://localhost:8100:
 
 ```sh
 curl http://localhost:8100/schema | jq .
 ```
 
-### Test an agent
+### Test a connector
 
 ```sh
 cargo run --bin ndc-test -- test --endpoint http://localhost:8100
@@ -63,7 +63,7 @@ cargo run --bin ndc-test -- replay --endpoint http://localhost:8100 --snapshots-
 
 Connector developers can add custom query and mutation snapshot tests to the snapshot directory. The `test` command does not generate mutation tests by default, because it is up to the connector developer to ensure a reproducible test environment.
 
-For example, to run the existing suite of snapshot tests for `ndc-reference`, we can use the replay command (assuming the reference agent is running on port 8100):
+For example, to run the existing suite of snapshot tests for `ndc-reference`, we can use the replay command (assuming the reference connector is running on port 8100):
 
 ```sh
 cargo run --bin ndc-test -- replay --endpoint http://localhost:8100 --snapshots-dir ndc-reference/tests

--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -318,7 +318,6 @@ pub struct Query {
 #[serde(tag = "type", rename_all = "snake_case")]
 #[schemars(title = "Aggregate")]
 pub enum Aggregate {
-    // TODO: do we need aggregation row limits?
     ColumnCount {
         /// The column to apply the count aggregate function to
         column: String,

--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -40,9 +40,9 @@ pub struct LeafCapability {}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[schemars(title = "Capabilities")]
 pub struct Capabilities {
-    pub query: Option<QueryCapabilities>,
+    pub query: QueryCapabilities,
     pub explain: Option<LeafCapability>,
-    pub relationships: Option<LeafCapability>,
+    pub relationships: Option<RelationshipCapabilities>,
 }
 // ANCHOR_END: Capabilities
 
@@ -51,14 +51,24 @@ pub struct Capabilities {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[schemars(title = "Query Capabilities")]
 pub struct QueryCapabilities {
-    /// Does the agent support comparisons that involve related collections (ie. joins)?
-    pub relation_comparisons: Option<LeafCapability>,
-    /// Does the agent support ordering by an aggregated array relationship?
-    pub order_by_aggregate: Option<LeafCapability>,
-    /// Does the agent support foreach queries, i.e. queries with variables
-    pub foreach: Option<LeafCapability>,
+    /// Does the connector support aggregate queries
+    pub aggregates: Option<LeafCapability>,
+    /// Does the connector support queries which use variables
+    pub variables: Option<LeafCapability>,
 }
 // ANCHOR_END: QueryCapabilities
+
+// ANCHOR: RelationshipCapabilities
+#[skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[schemars(title = "Relationship Capabilities")]
+pub struct RelationshipCapabilities {
+    /// Does the connector support comparisons that involve related collections (ie. joins)?
+    pub relation_comparisons: Option<LeafCapability>,
+    /// Does the connector support ordering by an aggregated array relationship?
+    pub order_by_aggregate: Option<LeafCapability>,
+}
+// ANCHOR_END: RelationshipCapabilities
 
 // ANCHOR: SchemaResponse
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -538,7 +548,7 @@ pub enum ExistsInCollection {
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[schemars(title = "Query Response")]
-/// Query responses may return multiple RowSets when using foreach queries
+/// Query responses may return multiple RowSets when using queries with variables.
 /// Else, there should always be exactly one RowSet
 pub struct QueryResponse(pub Vec<RowSet>);
 // ANCHOR_END: QueryResponse

--- a/ndc-client/tests/json_schema/capabilities_response.jsonschema
+++ b/ndc-client/tests/json_schema/capabilities_response.jsonschema
@@ -19,16 +19,12 @@
       "title": "Capabilities",
       "description": "Describes the features of the specification which a data connector implements.",
       "type": "object",
+      "required": [
+        "query"
+      ],
       "properties": {
         "query": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/QueryCapabilities"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/QueryCapabilities"
         },
         "explain": {
           "anyOf": [
@@ -43,7 +39,7 @@
         "relationships": {
           "anyOf": [
             {
-              "$ref": "#/definitions/LeafCapability"
+              "$ref": "#/definitions/RelationshipCapabilities"
             },
             {
               "type": "null"
@@ -56,8 +52,8 @@
       "title": "Query Capabilities",
       "type": "object",
       "properties": {
-        "relation_comparisons": {
-          "description": "Does the agent support comparisons that involve related collections (ie. joins)?",
+        "aggregates": {
+          "description": "Does the connector support aggregate queries",
           "anyOf": [
             {
               "$ref": "#/definitions/LeafCapability"
@@ -67,19 +63,8 @@
             }
           ]
         },
-        "order_by_aggregate": {
-          "description": "Does the agent support ordering by an aggregated array relationship?",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/LeafCapability"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "foreach": {
-          "description": "Does the agent support foreach queries, i.e. queries with variables",
+        "variables": {
+          "description": "Does the connector support queries which use variables",
           "anyOf": [
             {
               "$ref": "#/definitions/LeafCapability"
@@ -94,6 +79,34 @@
     "LeafCapability": {
       "description": "A unit value to indicate a particular leaf capability is supported. This is an empty struct to allow for future sub-capabilities.",
       "type": "object"
+    },
+    "RelationshipCapabilities": {
+      "title": "Relationship Capabilities",
+      "type": "object",
+      "properties": {
+        "relation_comparisons": {
+          "description": "Does the connector support comparisons that involve related collections (ie. joins)?",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "order_by_aggregate": {
+          "description": "Does the connector support ordering by an aggregated array relationship?",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/ndc-client/tests/json_schema/query_response.jsonschema
+++ b/ndc-client/tests/json_schema/query_response.jsonschema
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Query Response",
-  "description": "Query responses may return multiple RowSets when using foreach queries Else, there should always be exactly one RowSet",
+  "description": "Query responses may return multiple RowSets when using queries with variables. Else, there should always be exactly one RowSet",
   "type": "array",
   "items": {
     "$ref": "#/definitions/RowSet"

--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -13,7 +13,7 @@ use axum::{
 };
 
 use indexmap::IndexMap;
-use ndc_client::models::{self, LeafCapability};
+use ndc_client::models::{self, LeafCapability, RelationshipCapabilities};
 use prometheus::{Encoder, IntCounter, IntGauge, Opts, Registry, TextEncoder};
 use regex::Regex;
 use tokio::sync::Mutex;
@@ -165,12 +165,14 @@ async fn get_capabilities() -> Json<models::CapabilitiesResponse> {
         versions: "^0.1.0".into(),
         capabilities: models::Capabilities {
             explain: None,
-            query: Some(models::QueryCapabilities {
-                foreach: Some(LeafCapability {}),
+            query: models::QueryCapabilities {
+                aggregates: Some(LeafCapability {}),
+                variables: Some(LeafCapability {}),
+            },
+            relationships: Some(RelationshipCapabilities {
                 order_by_aggregate: Some(LeafCapability {}),
                 relation_comparisons: Some(LeafCapability {}),
             }),
-            relationships: Some(LeafCapability {}),
         },
     })
 }
@@ -1556,12 +1558,9 @@ async fn post_mutation(
     let mut operation_results = vec![];
 
     for operation in request.operations.iter() {
-        let operation_result = execute_mutation_operation(
-            &mut state,
-            &request.collection_relationships,
-            operation,
-        )
-        .await?;
+        let operation_result =
+            execute_mutation_operation(&mut state, &request.collection_relationships, operation)
+                .await?;
         operation_results.push(operation_result);
     }
 

--- a/ndc-reference/tests/capabilities/expected.json
+++ b/ndc-reference/tests/capabilities/expected.json
@@ -2,10 +2,12 @@
   "versions": "^0.1.0",
   "capabilities": {
     "query": {
-      "relation_comparisons": {},
-      "order_by_aggregate": {},
-      "foreach": {}
+      "aggregates": {},
+      "variables": {}
     },
-    "relationships": {}
+    "relationships": {
+      "relation_comparisons": {},
+      "order_by_aggregate": {}
+    }
   }
 }

--- a/specification/src/reference/types.md
+++ b/specification/src/reference/types.md
@@ -222,6 +222,12 @@
 {{#include ../../../ndc-client/src/models.rs:RelationshipArgument}}
 ```
 
+## `RelationshipCapabilities`
+
+```rust,no_run,noplayground
+{{#include ../../../ndc-client/src/models.rs:RelationshipCapabilities}}
+```
+
 ## `RelationshipType`
 
 ```rust,no_run,noplayground

--- a/specification/src/specification/capabilities.md
+++ b/specification/src/specification/capabilities.md
@@ -20,18 +20,15 @@ See [`CapabilitiesResponse`](../reference/types.md#capabilitiesresponse)
 
 ## Response Fields
 
-_TODO_: relation_comparisons seem like special cases of relationships
-
-_TODO_: the code doesn't actually follow this response format right now
-
 | Name | Description |
 |------|-------------|
-| `versions` | A [semantic versioning](https://semver.org) range of API versions which the data connector claims to implement |
-| `capabilities.query.foreach` | Whether the data connector supports [`foreach` queries](queries/foreach.md) |
-| `capabilities.query.relation_comparisons` | Whether comparisons can include columns reachable via [relationships](queries/relationships.md) |
-| `capabilities.query.order_by_aggregate` | Whether order by clauses can include aggregates |
-| `capabilities.explain` | Whether the data connector is capable of describing query plans |
+| `versions` | A [semantic versioning](https://semver.org) range of API versions which the data connector 
+| `capabilities.explain` | Whether the data connector is capable of describing query plans |claims to implement |
+| `capabilities.query.aggregates` | Whether the data connector supports [aggregate queries](queries/aggregates.md) |
+| `capabilities.query.variables` | Whether the data connector supports [queries with variables](queries/variables.md) |
 | `capabilities.relationships` | Whether the data connector supports [relationships](queries/relationships.md) |
+| `capabilities.relationships.order_by_aggregate` | Whether order by clauses can include aggregates |
+| `capabilities.relationships.relation_comparisons` | Whether comparisons can include columns reachable via [relationships](queries/relationships.md) |
 
 ## See also
 

--- a/specification/src/specification/changelog.md
+++ b/specification/src/specification/changelog.md
@@ -12,11 +12,11 @@ Collection names are now single strings instead of arrays of strings. The array 
 
 ### No Configuration
 
-The configuration header convention was removed. Agents are now expected to manage their own configuration, and an agent URL fully represents that agent with its pre-specified configuration.
+The configuration header convention was removed. Connectors are now expected to manage their own configuration, and a connector URL fully represents that connector with its pre-specified configuration.
 
 ### No Database Concepts in GDC
 
-GDC no longer sends any metadata to indicate database-specific concepts. For example, a Collection used to indicate whether it was a Collection or view. Such metadata would be passed back in the query IR, to help the agent disambiguate which database object to query. When we proposed adding functions, we would have had to add a new type to disambiguate nullary functions from collections, etc. Instead, we now expect agents to understand their own schema, and understand the query IR that they receive, as long as it is compatible with their GDC schema.
+GDC no longer sends any metadata to indicate database-specific concepts. For example, a Collection used to indicate whether it was a Collection or view. Such metadata would be passed back in the query IR, to help the connector disambiguate which database object to query. When we proposed adding functions, we would have had to add a new type to disambiguate nullary functions from collections, etc. Instead, we now expect connectors to understand their own schema, and understand the query IR that they receive, as long as it is compatible with their GDC schema.
 
 Column types are no longer sent in the query and mutation requests.
 
@@ -38,7 +38,7 @@ Field arguments were added to fields in order to support use cases like computed
 
 The equality operator is now expected on every scalar type implicitly. 
 
-_Note_: it was already implicitly supported by any agent advertising the `foreach` capability, which imposes column equality constraints in each row set fetched in a forall query.
+_Note_: it was already implicitly supported by any connector advertising the `variables` capability, which imposes column equality constraints in each row set fetched in a forall query.
 
 The equality operator will have semantics assigned for the purposes of testing.
 

--- a/specification/src/specification/queries/variables.md
+++ b/specification/src/specification/queries/variables.md
@@ -2,7 +2,7 @@
 
 A [`QueryRequest`](../../reference/types.md#queryrequest) can optionally specify one or more sets of variables which can be referenced throughout the [`Query`](../../reference/types.md#query) object. 
 
-Query variables will only be provided if the `foreach` [capability](../capabilities.md) is advertised in the capabilities response.
+Query variables will only be provided if the `query.variables` [capability](../capabilities.md) is advertised in the capabilities response.
 
 The intent is that the data connector should attempt to perform multiple versions of the query in parallel - one instance of the query for each set of variables. For each set of variables, each variable value should be substituted wherever it is referenced in the query - for example in a [`ComparisonValue`](../../reference/types.md#comparisonvalue).
 


### PR DESCRIPTION
Some breaking changes to capabilities before 0.1.0:

- Add an `aggregates` capability
- Move `relation_comparisons` and `order_by_aggregate` under relationship, since they require it
- Make `query` non-optional (it will only exist to contain `aggregates` and `variables` and group together other query-related things
- Rename `foreach` to `variables`