### PR TITLE
Upgrade indexmap to v2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,9 +647,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "heck"
@@ -792,12 +792,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.2",
+ "serde",
 ]
 
 [[package]]
@@ -970,7 +971,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "goldenfile",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "opentelemetry",
  "reqwest",
  "schemars",
@@ -989,7 +990,7 @@ dependencies = [
  "axum",
  "csv",
  "goldenfile",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "ndc-client",
  "ndc-test",
  "prometheus",
@@ -1006,7 +1007,7 @@ dependencies = [
  "async-trait",
  "clap",
  "colored",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "ndc-client",
  "proptest",
  "reqwest",
@@ -1489,6 +1490,7 @@ checksum = "1f7b0ce13155372a76ee2e1c5ffba1fe61ede73fbea5630d61eee6fac4929c0c"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -1579,7 +1581,7 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",

--- a/ndc-client/Cargo.toml
+++ b/ndc-client/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 
 [dependencies]
 async-trait = "^0.1.74"
-indexmap = { version = "^1", features = ["serde"] }
+indexmap = { version = "2.1.0", features = ["serde"] }
 opentelemetry = "^0.20.0"
 reqwest = { version = "^0.11", features = ["json", "multipart"] }
-schemars = { version = "^0.8.15", features = ["smol_str", "indexmap1", "preserve_order"] }
+schemars = { version = "^0.8.15", features = ["indexmap2", "preserve_order", "smol_str"] }
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = { version = "^1.0", features = ["preserve_order"] }

--- a/ndc-reference/Cargo.toml
+++ b/ndc-reference/Cargo.toml
@@ -12,7 +12,7 @@ ndc-client = { path = "../ndc-client" }
 
 axum = "^0.6.20"
 csv = "^1.3.0"
-indexmap = "^1"
+indexmap = { version = "^2", features = ["serde"] }
 prometheus = "^0.13.3"
 regex = "^1.10.2"
 serde_json = "^1.0.107"

--- a/ndc-test/Cargo.toml
+++ b/ndc-test/Cargo.toml
@@ -5,11 +5,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+ndc-client = { path = "../ndc-client" }
+
 async-trait = "^0.1.74"
 clap = { version = "^4", features = ["derive"] }
 colored = "^2.0.4"
-indexmap = { version = "^1", features = ["serde"] }
-ndc-client = { path = "../ndc-client" }
+indexmap = { version = "^2", features = ["serde"] }
 proptest = "^1.3.1"
 reqwest = { version = "^0.11", features = ["json", "multipart"] }
 semver = "^1.0.20"


### PR DESCRIPTION
Let's bump this before stabilizing. It means all consumers can use indexmap v2 as well.

indexmap v1 is still used internally by a couple of dependencies, but hopefully those will fade away over time. They do not pollute the public API.