### PR TITLE
Add a note about HTTP error 422 Unprocessable Content

### DIFF
--- a/specification/src/specification/error-handling.md
+++ b/specification/src/specification/error-handling.md
@@ -10,6 +10,7 @@ Data connectors should use standard HTTP error codes to signal error conditions 
 | 400 | Bad Request | The request did not match the data connector's expectation based on this specification. |
 | 403 | Forbidden | The request could not be handled because a permission check failed - for example, a mutation might fail because a check constraint was not met. |
 | 409 | Conflict | The request could not be handled because it would create a conflicting state for the data source - for example, a mutation might fail because a foreign key constraint was not met. |
+| 422 | Unprocessable Content | The request could not be handled because, while the request was well-formed, it was not semantically correct. For example, a value for a custom scalar type was provided, but with an incorrect type. |
 | 500 | Internal Server Error | The request could not be handled because of an error on the server |
 | 501 | Not Supported | The request could not be handled because it relies on an unsupported [capability](capabilities.md). _Note_: this ought to indicate an error on the _caller_ side, since the caller should not generate requests which are incompatible with the indicated capabilities. |
 | 502 | Bad Gateway | The request could not be handled because an upstream service was unavailable or returned an unexpected response, e.g., a connection to a database server failed |


### PR DESCRIPTION
I was planning to add a custom error code, `499 Well Formed` to indicate that the query/mutation IR is syntactically valid, but semantically invalid, e.g. you passed a string which should have parsed as an integer. However, a bit of digging reveals that `422 Unprocessable Content` is basically exactly this:

```
11.2.  422 Unprocessable Entity

   The 422 (Unprocessable Entity) status code means the server
   understands the content type of the request entity (hence a
   415(Unsupported Media Type) status code is inappropriate), and the
   syntax of the request entity is correct (thus a 400 (Bad Request)
   status code is inappropriate) but was unable to process the contained
   instructions.  For example, this error condition may occur if an XML
   request body contains well-formed (i.e., syntactically correct), but
   semantically erroneous, XML instructions.
```

It was added to HTTP 1.1 as part of WebDAV but AFAICT is more generally applicable, so I'm going to recommend we use that.