### PR TITLE
Add a capability for transactional mutations

### DIFF
--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -42,7 +42,7 @@ pub struct LeafCapability {}
 pub struct Capabilities {
     pub query: QueryCapabilities,
     pub explain: Option<LeafCapability>,
-    pub mutation: Option<MutationCapabilities>,
+    pub mutation: MutationCapabilities,
     pub relationships: Option<RelationshipCapabilities>,
 }
 // ANCHOR_END: Capabilities

--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -42,6 +42,7 @@ pub struct LeafCapability {}
 pub struct Capabilities {
     pub query: QueryCapabilities,
     pub explain: Option<LeafCapability>,
+    pub mutation: Option<MutationCapabilities>,
     pub relationships: Option<RelationshipCapabilities>,
 }
 // ANCHOR_END: Capabilities
@@ -57,6 +58,16 @@ pub struct QueryCapabilities {
     pub variables: Option<LeafCapability>,
 }
 // ANCHOR_END: QueryCapabilities
+
+// ANCHOR: MutationCapabilities
+#[skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[schemars(title = "Mutation Capabilities")]
+pub struct MutationCapabilities {
+    /// Does the connector support executing multiple mutations in a transaction.
+    pub transactional: Option<LeafCapability>,
+}
+// ANCHOR_END: MutationCapabilities
 
 // ANCHOR: RelationshipCapabilities
 #[skip_serializing_none]

--- a/ndc-client/tests/json_schema/capabilities_response.jsonschema
+++ b/ndc-client/tests/json_schema/capabilities_response.jsonschema
@@ -36,6 +36,16 @@
             }
           ]
         },
+        "mutation": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MutationCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "relationships": {
           "anyOf": [
             {
@@ -79,6 +89,23 @@
     "LeafCapability": {
       "description": "A unit value to indicate a particular leaf capability is supported. This is an empty struct to allow for future sub-capabilities.",
       "type": "object"
+    },
+    "MutationCapabilities": {
+      "title": "Mutation Capabilities",
+      "type": "object",
+      "properties": {
+        "transactional": {
+          "description": "Does the connector support executing multiple mutations in a transaction.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
     },
     "RelationshipCapabilities": {
       "title": "Relationship Capabilities",

--- a/ndc-client/tests/json_schema/capabilities_response.jsonschema
+++ b/ndc-client/tests/json_schema/capabilities_response.jsonschema
@@ -20,6 +20,7 @@
       "description": "Describes the features of the specification which a data connector implements.",
       "type": "object",
       "required": [
+        "mutation",
         "query"
       ],
       "properties": {
@@ -37,14 +38,7 @@
           ]
         },
         "mutation": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/MutationCapabilities"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/MutationCapabilities"
         },
         "relationships": {
           "anyOf": [

--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -169,6 +169,9 @@ async fn get_capabilities() -> Json<models::CapabilitiesResponse> {
                 aggregates: Some(LeafCapability {}),
                 variables: Some(LeafCapability {}),
             },
+            mutation: Some(models::MutationCapabilities {
+                transactional: None,
+            }),
             relationships: Some(RelationshipCapabilities {
                 order_by_aggregate: Some(LeafCapability {}),
                 relation_comparisons: Some(LeafCapability {}),
@@ -1555,17 +1558,30 @@ async fn post_mutation(
 ) -> Result<Json<models::MutationResponse>> {
     // ANCHOR_END: post_mutation_signature
     // ANCHOR: post_mutation
-    let mut state = state.lock().await;
+    if request.operations.len() > 1 {
+        Err((
+            StatusCode::NOT_IMPLEMENTED,
+            Json(models::ErrorResponse {
+                message: "transactional mutations are not supported".into(),
+                details: serde_json::Value::Null,
+            }),
+        ))
+    } else {
+        let mut state = state.lock().await;
 
-    let mut operation_results = vec![];
+        let mut operation_results = vec![];
 
-    for operation in request.operations.iter() {
-        let operation_result =
-            execute_mutation_operation(&mut state, &request.collection_relationships, operation)?;
-        operation_results.push(operation_result);
+        for operation in request.operations.iter() {
+            let operation_result = execute_mutation_operation(
+                &mut state,
+                &request.collection_relationships,
+                operation,
+            )?;
+            operation_results.push(operation_result);
+        }
+
+        Ok(Json(models::MutationResponse { operation_results }))
     }
-
-    Ok(Json(models::MutationResponse { operation_results }))
 }
 // ANCHOR_END: post_mutation
 // ANCHOR: execute_mutation_operation

--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -169,9 +169,9 @@ async fn get_capabilities() -> Json<models::CapabilitiesResponse> {
                 aggregates: Some(LeafCapability {}),
                 variables: Some(LeafCapability {}),
             },
-            mutation: Some(models::MutationCapabilities {
+            mutation: models::MutationCapabilities {
                 transactional: None,
-            }),
+            },
             relationships: Some(RelationshipCapabilities {
                 order_by_aggregate: Some(LeafCapability {}),
                 relation_comparisons: Some(LeafCapability {}),

--- a/ndc-reference/tests/capabilities/expected.json
+++ b/ndc-reference/tests/capabilities/expected.json
@@ -5,6 +5,7 @@
       "aggregates": {},
       "variables": {}
     },
+    "mutation": {},
     "relationships": {
       "relation_comparisons": {},
       "order_by_aggregate": {}

--- a/ndc-reference/tests/mutation/upsert_article/expected.json
+++ b/ndc-reference/tests/mutation/upsert_article/expected.json
@@ -7,16 +7,6 @@
           "__value": null
         }
       ]
-    },
-    {
-      "affected_rows": 1,
-      "returning": [
-        {
-          "__value": {
-            "id": 2
-          }
-        }
-      ]
     }
   ]
 }

--- a/ndc-reference/tests/mutation/upsert_article/request.json
+++ b/ndc-reference/tests/mutation/upsert_article/request.json
@@ -18,23 +18,6 @@
                     "column": "id"
                 }
             }
-        },
-        {
-            "type": "procedure",
-            "name": "upsert_article",
-            "arguments": {
-                "article": {
-                    "id": 2,
-                    "title": "QuickCheck: a lightweight tool for random testing of Haskell programs",
-                    "author_id": 2
-                }
-            },
-            "fields": {
-                "id": {
-                    "type": "column",
-                    "column": "id"
-                }
-            }
         }
     ],
     "collection_relationships": {}

--- a/specification/src/specification/capabilities.md
+++ b/specification/src/specification/capabilities.md
@@ -22,8 +22,10 @@ See [`CapabilitiesResponse`](../reference/types.md#capabilitiesresponse)
 
 | Name | Description |
 |------|-------------|
-| `versions` | A [semantic versioning](https://semver.org) range of API versions which the data connector 
+| `versions` | A [semantic versioning](https://semver.org) range of API versions which the data connector
 | `capabilities.explain` | Whether the data connector is capable of describing query plans |claims to implement |
+| `capabilities.mutation` | Whether the data connector is capable of executing mutations |claims to implement |
+| `capabilities.mutation.transactional` | Whether the data connector is capable of executing multiple mutations in a transaction |claims to implement |
 | `capabilities.query.aggregates` | Whether the data connector supports [aggregate queries](queries/aggregates.md) |
 | `capabilities.query.variables` | Whether the data connector supports [queries with variables](queries/variables.md) |
 | `capabilities.relationships` | Whether the data connector supports [relationships](queries/relationships.md) |
@@ -35,3 +37,4 @@ See [`CapabilitiesResponse`](../reference/types.md#capabilitiesresponse)
 - Type [`Capabilities`](../reference/types.md#capabilities)
 - Type [`CapabilitiesResponse`](../reference/types.md#capabilitiesresponse)
 - Type [`QueryCapabilities`](../reference/types.md#querycapabilities)
+- Type [`MutationCapabilities`](../reference/types.md#mutationcapabilities)

--- a/specification/src/specification/capabilities.md
+++ b/specification/src/specification/capabilities.md
@@ -22,10 +22,9 @@ See [`CapabilitiesResponse`](../reference/types.md#capabilitiesresponse)
 
 | Name | Description |
 |------|-------------|
-| `versions` | A [semantic versioning](https://semver.org) range of API versions which the data connector
-| `capabilities.explain` | Whether the data connector is capable of describing query plans |claims to implement |
-| `capabilities.mutation` | Whether the data connector is capable of executing mutations |claims to implement |
-| `capabilities.mutation.transactional` | Whether the data connector is capable of executing multiple mutations in a transaction |claims to implement |
+| `versions` | A [semantic versioning](https://semver.org) range of API versions which the data connector |
+| `capabilities.explain` | Whether the data connector is capable of describing query plans |
+| `capabilities.mutation.transactional` | Whether the data connector is capable of executing multiple mutations in a transaction |
 | `capabilities.query.aggregates` | Whether the data connector supports [aggregate queries](queries/aggregates.md) |
 | `capabilities.query.variables` | Whether the data connector supports [queries with variables](queries/variables.md) |
 | `capabilities.relationships` | Whether the data connector supports [relationships](queries/relationships.md) |

--- a/specification/src/specification/mutations/README.md
+++ b/specification/src/specification/mutations/README.md
@@ -25,6 +25,15 @@ See [`MutationRequest`](../../reference/types.md#mutationrequest)
 
 Each operation is described by a [`MutationOperation`](../../reference/types.md#mutationoperation) structure, which can be one of several types. However, currently [procedures](./procedures.md) are the only supported operation type.
 
+### Multiple Operations
+
+If the `mutation.transactional` capability is enabled, then the caller may provide multiple operations in a single request.
+Otherwise, the caller must provide exactly one operation.
+
+The intent is that multiple operations ought to be performed together in a single transaction.
+That is, they should all succeed, or all fail together. If any operation fails, then a single `ErrorResponse` should capture
+the failure, and none of the operations should effect any changes to the data source.
+
 ## Response
 
 See [`MutationResponse`](../../reference/types.md#mutationresponse)

--- a/specification/src/specification/mutations/README.md
+++ b/specification/src/specification/mutations/README.md
@@ -1,6 +1,6 @@
 # Mutations
 
-The mutation endpoint accepts a mutation request, containing a collection of mutation operations to be performed in the context the data source, and returns a response containing a result for each operation.
+The mutation endpoint accepts a mutation request, containing a collection of mutation operations to be performed transactionally in the context the data source, and returns a response containing a result for each operation.
 
 The structure and requirements for specific fields listed below will be covered in subsequent chapters.
 


### PR DESCRIPTION
This PR encodes the support a connector offers wrt mutations in types.
It introduces a new capability, `mutation`, to signal whether the connector supports mutations, and a field in `MutationCapabilities`, `transactional`, to signal whether the connector support running multiple mutations in a single transaction.

Additional discussion on Slack: https://hasurahq.slack.com/archives/C065TFX2V2Q/p1702996285519119