### PR TITLE
add alias to PathElement predicate expression

### DIFF
--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -496,6 +496,7 @@ pub struct PathElement {
     /// Values to be provided to any collection arguments
     pub arguments: BTreeMap<String, RelationshipArgument>,
     /// A predicate expression to apply to the target collection
+    #[serde(rename = "where")]
     pub predicate: Box<Expression>,
 }
 // ANCHOR_END: PathElement

--- a/ndc-client/tests/json_schema/mutation_request.jsonschema
+++ b/ndc-client/tests/json_schema/mutation_request.jsonschema
@@ -379,8 +379,8 @@
       "type": "object",
       "required": [
         "arguments",
-        "predicate",
-        "relationship"
+        "relationship",
+        "where"
       ],
       "properties": {
         "relationship": {
@@ -394,7 +394,7 @@
             "$ref": "#/definitions/RelationshipArgument"
           }
         },
-        "predicate": {
+        "where": {
           "description": "A predicate expression to apply to the target collection",
           "allOf": [
             {

--- a/ndc-client/tests/json_schema/query_request.jsonschema
+++ b/ndc-client/tests/json_schema/query_request.jsonschema
@@ -424,8 +424,8 @@
       "type": "object",
       "required": [
         "arguments",
-        "predicate",
-        "relationship"
+        "relationship",
+        "where"
       ],
       "properties": {
         "relationship": {
@@ -439,7 +439,7 @@
             "$ref": "#/definitions/RelationshipArgument"
           }
         },
-        "predicate": {
+        "where": {
           "description": "A predicate expression to apply to the target collection",
           "allOf": [
             {

--- a/ndc-reference/tests/query/order_by_aggregate/request.json
+++ b/ndc-reference/tests/query/order_by_aggregate/request.json
@@ -35,7 +35,7 @@
                             {
                                 "arguments": {},
                                 "relationship": "author_articles",
-                                "predicate": {
+                                "where": {
                                     "type": "and",
                                     "expressions": []
                                 }

--- a/ndc-reference/tests/query/order_by_aggregate_function/request.json
+++ b/ndc-reference/tests/query/order_by_aggregate_function/request.json
@@ -39,7 +39,7 @@
                             {
                                 "arguments": {},
                                 "relationship": "author_articles",
-                                "predicate": {
+                                "where": {
                                     "type": "and",
                                     "expressions": []
                                 }

--- a/ndc-reference/tests/query/order_by_aggregate_with_predicate/request.json
+++ b/ndc-reference/tests/query/order_by_aggregate_with_predicate/request.json
@@ -48,7 +48,7 @@
                             {
                                 "arguments": {},
                                 "relationship": "author_articles",
-                                "predicate": {
+                                "where": {
                                     "type": "binary_comparison_operator",
                                     "column": {
                                         "type": "column",

--- a/ndc-reference/tests/query/order_by_relationship/request.json
+++ b/ndc-reference/tests/query/order_by_relationship/request.json
@@ -40,7 +40,7 @@
                             {
                                 "arguments": {},
                                 "relationship": "article_author",
-                                "predicate": {
+                                "where": {
                                     "type": "and",
                                     "expressions": []
                                 }
@@ -57,7 +57,7 @@
                             {
                                 "arguments": {},
                                 "relationship": "article_author",
-                                "predicate": {
+                                "where": {
                                     "type": "and",
                                     "expressions": []
                                 }

--- a/ndc-reference/tests/query/predicate_with_array_relationship/request.json
+++ b/ndc-reference/tests/query/predicate_with_array_relationship/request.json
@@ -38,7 +38,7 @@
                 "path": [{
                     "arguments": {},
                     "relationship": "author_articles",
-                    "predicate": {
+                    "where": {
                         "type": "and",
                         "expressions": []
                     }

--- a/ndc-reference/tests/query/predicate_with_nondet_in_1/request.json
+++ b/ndc-reference/tests/query/predicate_with_nondet_in_1/request.json
@@ -26,7 +26,7 @@
                     {
                         "relationship": "author_articles",
                         "arguments": {},
-                        "predicate": {
+                        "where": {
                             "type": "and",
                             "expressions": []
                         }

--- a/ndc-reference/tests/query/table_argument_order_by/request.json
+++ b/ndc-reference/tests/query/table_argument_order_by/request.json
@@ -24,7 +24,7 @@
                                     }
                                 },
                                 "relationship": "author_articles",
-                                "predicate": {
+                                "where": {
                                     "type": "and",
                                     "expressions": []
                                 }

--- a/ndc-reference/tests/query/table_argument_predicate/request.json
+++ b/ndc-reference/tests/query/table_argument_predicate/request.json
@@ -23,7 +23,7 @@
                             }
                         },
                         "relationship": "author_articles",
-                        "predicate": {
+                        "where": {
                             "type": "and",
                             "expressions": []
                         }


### PR DESCRIPTION
We alias `where` expressions to `predicate`, in part because `where` is a reserved keyword in rust.

The `PathElement` does not follow this pattern.
We should make the behavior consistent. For now I've only commited the change to add the missing alias. Do note this means a change in the expected payload, so we'll need to update schemas and tests too.

Before I do that, I'd like us to consider 3 different approaches and make a descision:

1. Preserve the status quo, making things consistent. The expected json key would be `where`, and for rust the key is alliased to `predicate`
2. Change all rust keys to `r#where`. This is the standard way to get around reserved keywords, and would make it clear from the struct keys what the expected IR looks like. The IR would still expect the keys to be `where`
3. Change all keys to be `predicate`, in both the rust SDK _and_ the IR. This is the most disruptive.

I'm ambivalent about either option 2 or 3, but dislike option 1.