### PR TITLE
Rename-where-to-predicate

### DIFF
--- a/ndc-client/src/apis/default_api.rs
+++ b/ndc-client/src/apis/default_api.rs
@@ -52,8 +52,6 @@ pub async fn capabilities_get(
     let tracer = global::tracer("engine");
     tracer
         .in_span("capabilities_get", |ctx| async {
-            let configuration = configuration;
-
             let client = &configuration.client;
 
             let uri = append_path(&configuration.base_path, "capabilities")
@@ -91,8 +89,6 @@ pub async fn explain_post(
     let tracer = global::tracer("engine");
     tracer
         .in_span("explain_post", |ctx| async {
-            let configuration = configuration;
-
             let client = &configuration.client;
 
             let uri = append_path(&configuration.base_path, "explain")
@@ -132,8 +128,6 @@ pub async fn mutation_post(
     let tracer = global::tracer("engine");
     tracer
         .in_span("mutation_post", |ctx| async {
-            let configuration = configuration;
-
             let client = &configuration.client;
 
             let uri = append_path(&configuration.base_path, "mutation")
@@ -174,8 +168,6 @@ pub async fn query_post(
     tracer
         .in_span("query_post", |ctx| {
             async {
-                let configuration = configuration;
-
                 let client = &configuration.client;
 
                 let uri = append_path(&configuration.base_path, "query")
@@ -217,8 +209,6 @@ pub async fn schema_get(
     let tracer = global::tracer("engine");
     tracer
         .in_span("schema_get", |ctx| async {
-            let configuration = configuration;
-
             let client = &configuration.client;
 
             let uri = append_path(&configuration.base_path, "schema")

--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -324,7 +324,6 @@ pub struct Query {
     /// Optionally offset from the Nth result
     pub offset: Option<u32>,
     pub order_by: Option<OrderBy>,
-    #[serde(rename = "where")]
     pub predicate: Option<Expression>,
 }
 // ANCHOR_END: Query
@@ -450,8 +449,7 @@ pub enum Expression {
     },
     Exists {
         in_collection: ExistsInCollection,
-        #[serde(rename = "where")]
-        predicate: Box<Expression>,
+        predicate: Option<Box<Expression>>,
     },
 }
 // ANCHOR_END: Expression
@@ -496,8 +494,7 @@ pub struct PathElement {
     /// Values to be provided to any collection arguments
     pub arguments: BTreeMap<String, RelationshipArgument>,
     /// A predicate expression to apply to the target collection
-    #[serde(rename = "where")]
-    pub predicate: Box<Expression>,
+    pub predicate: Option<Box<Expression>>,
 }
 // ANCHOR_END: PathElement
 

--- a/ndc-client/tests/json_schema/mutation_request.jsonschema
+++ b/ndc-client/tests/json_schema/mutation_request.jsonschema
@@ -169,7 +169,7 @@
             }
           ]
         },
-        "where": {
+        "predicate": {
           "anyOf": [
             {
               "$ref": "#/definitions/Expression"
@@ -379,8 +379,7 @@
       "type": "object",
       "required": [
         "arguments",
-        "relationship",
-        "where"
+        "relationship"
       ],
       "properties": {
         "relationship": {
@@ -394,11 +393,14 @@
             "$ref": "#/definitions/RelationshipArgument"
           }
         },
-        "where": {
+        "predicate": {
           "description": "A predicate expression to apply to the target collection",
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/Expression"
+            },
+            {
+              "type": "null"
             }
           ]
         }
@@ -578,8 +580,7 @@
           "type": "object",
           "required": [
             "in_collection",
-            "type",
-            "where"
+            "type"
           ],
           "properties": {
             "type": {
@@ -591,8 +592,15 @@
             "in_collection": {
               "$ref": "#/definitions/ExistsInCollection"
             },
-            "where": {
-              "$ref": "#/definitions/Expression"
+            "predicate": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expression"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           }
         }

--- a/ndc-client/tests/json_schema/query_request.jsonschema
+++ b/ndc-client/tests/json_schema/query_request.jsonschema
@@ -101,7 +101,7 @@
             }
           ]
         },
-        "where": {
+        "predicate": {
           "anyOf": [
             {
               "$ref": "#/definitions/Expression"
@@ -424,8 +424,7 @@
       "type": "object",
       "required": [
         "arguments",
-        "relationship",
-        "where"
+        "relationship"
       ],
       "properties": {
         "relationship": {
@@ -439,11 +438,14 @@
             "$ref": "#/definitions/RelationshipArgument"
           }
         },
-        "where": {
+        "predicate": {
           "description": "A predicate expression to apply to the target collection",
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/Expression"
+            },
+            {
+              "type": "null"
             }
           ]
         }
@@ -564,8 +566,7 @@
           "type": "object",
           "required": [
             "in_collection",
-            "type",
-            "where"
+            "type"
           ],
           "properties": {
             "type": {
@@ -577,8 +578,15 @@
             "in_collection": {
               "$ref": "#/definitions/ExistsInCollection"
             },
-            "where": {
-              "$ref": "#/definitions/Expression"
+            "predicate": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expression"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           }
         }

--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -1080,7 +1080,7 @@ fn eval_path_element(
                         collection_relationships,
                         variables,
                         state,
-                        &expression,
+                        expression,
                         tgt_row,
                         tgt_row,
                     )?

--- a/ndc-reference/tests/query/order_by_aggregate/request.json
+++ b/ndc-reference/tests/query/order_by_aggregate/request.json
@@ -35,7 +35,7 @@
                             {
                                 "arguments": {},
                                 "relationship": "author_articles",
-                                "where": {
+                                "predicate": {
                                     "type": "and",
                                     "expressions": []
                                 }

--- a/ndc-reference/tests/query/order_by_aggregate_function/request.json
+++ b/ndc-reference/tests/query/order_by_aggregate_function/request.json
@@ -39,7 +39,7 @@
                             {
                                 "arguments": {},
                                 "relationship": "author_articles",
-                                "where": {
+                                "predicate": {
                                     "type": "and",
                                     "expressions": []
                                 }

--- a/ndc-reference/tests/query/order_by_aggregate_with_predicate/request.json
+++ b/ndc-reference/tests/query/order_by_aggregate_with_predicate/request.json
@@ -22,7 +22,7 @@
                             "type": "star_count"
                         }
                     },
-                    "where": {
+                    "predicate": {
                         "type": "binary_comparison_operator",
                         "column": {
                             "type": "column",
@@ -48,7 +48,7 @@
                             {
                                 "arguments": {},
                                 "relationship": "author_articles",
-                                "where": {
+                                "predicate": {
                                     "type": "binary_comparison_operator",
                                     "column": {
                                         "type": "column",

--- a/ndc-reference/tests/query/order_by_relationship/request.json
+++ b/ndc-reference/tests/query/order_by_relationship/request.json
@@ -40,7 +40,7 @@
                             {
                                 "arguments": {},
                                 "relationship": "article_author",
-                                "where": {
+                                "predicate": {
                                     "type": "and",
                                     "expressions": []
                                 }
@@ -57,7 +57,7 @@
                             {
                                 "arguments": {},
                                 "relationship": "article_author",
-                                "where": {
+                                "predicate": {
                                     "type": "and",
                                     "expressions": []
                                 }

--- a/ndc-reference/tests/query/predicate_with_array_relationship/request.json
+++ b/ndc-reference/tests/query/predicate_with_array_relationship/request.json
@@ -30,7 +30,7 @@
                 }
             }
         },
-        "where": {
+        "predicate": {
             "type": "binary_comparison_operator",
             "column": {
                 "type": "column",
@@ -38,7 +38,7 @@
                 "path": [{
                     "arguments": {},
                     "relationship": "author_articles",
-                    "where": {
+                    "predicate": {
                         "type": "and",
                         "expressions": []
                     }

--- a/ndc-reference/tests/query/predicate_with_eq/request.json
+++ b/ndc-reference/tests/query/predicate_with_eq/request.json
@@ -13,7 +13,7 @@
                 "column": "title"
             }
         },
-        "where": {
+        "predicate": {
             "type": "binary_comparison_operator",
             "column": {
                 "type": "column",

--- a/ndc-reference/tests/query/predicate_with_exists/request.json
+++ b/ndc-reference/tests/query/predicate_with_exists/request.json
@@ -30,14 +30,14 @@
                 }
             }
         },
-        "where": {
+        "predicate": {
             "type": "exists",
             "in_collection": {
                 "type": "related",
                 "arguments": {},
                 "relationship": "author_articles"
             },
-            "where": {
+            "predicate": {
                 "type": "binary_comparison_operator",
                 "column": {
                     "type": "column",

--- a/ndc-reference/tests/query/predicate_with_in/request.json
+++ b/ndc-reference/tests/query/predicate_with_in/request.json
@@ -13,7 +13,7 @@
                 "column": "title"
             }
         },
-        "where": {
+        "predicate": {
             "type": "binary_comparison_operator",
             "column": {
                 "type": "column",

--- a/ndc-reference/tests/query/predicate_with_like/request.json
+++ b/ndc-reference/tests/query/predicate_with_like/request.json
@@ -13,7 +13,7 @@
                 "column": "title"
             }
         },
-        "where": {
+        "predicate": {
             "type": "binary_comparison_operator",
             "column": {
                 "type": "column",

--- a/ndc-reference/tests/query/predicate_with_nondet_in_1/request.json
+++ b/ndc-reference/tests/query/predicate_with_nondet_in_1/request.json
@@ -17,7 +17,7 @@
                 "column": "last_name"
             }
         },
-        "where": {
+        "predicate": {
             "type": "binary_comparison_operator",
             "column": {
                 "type": "column",
@@ -26,7 +26,7 @@
                     {
                         "relationship": "author_articles",
                         "arguments": {},
-                        "where": {
+                        "predicate": {
                             "type": "and",
                             "expressions": []
                         }

--- a/ndc-reference/tests/query/predicate_with_unrelated_exists/request.json
+++ b/ndc-reference/tests/query/predicate_with_unrelated_exists/request.json
@@ -30,14 +30,14 @@
                 }
             }
         },
-        "where": {
+        "predicate": {
             "type": "exists",
             "in_collection": {
                 "type": "unrelated",
                 "arguments": {},
                 "collection": "articles"
             },
-            "where": {
+            "predicate": {
                 "type": "and",
                 "expressions": [
                     {

--- a/ndc-reference/tests/query/predicate_with_unrelated_exists_and_relationship/request.json
+++ b/ndc-reference/tests/query/predicate_with_unrelated_exists_and_relationship/request.json
@@ -35,14 +35,14 @@
                             }
                         }
                     },
-                    "where": {
+                    "predicate": {
                         "type": "exists",
                         "in_collection": {
                             "type": "unrelated",
                             "arguments": {},
                             "collection": "articles"
                         },
-                        "where": {
+                        "predicate": {
                             "type": "and",
                             "expressions": [
                                 {

--- a/ndc-reference/tests/query/table_argument_exists/request.json
+++ b/ndc-reference/tests/query/table_argument_exists/request.json
@@ -9,7 +9,7 @@
                 "column": "id"
             }
         },
-        "where": {
+        "predicate": {
             "type": "exists",
             "in_collection": {
                 "type": "related",
@@ -21,7 +21,7 @@
                 },
                 "relationship": "author_articles"
             },
-            "where": {
+            "predicate": {
                 "type": "binary_comparison_operator",
                 "column": {
                     "type": "column",

--- a/ndc-reference/tests/query/table_argument_order_by/request.json
+++ b/ndc-reference/tests/query/table_argument_order_by/request.json
@@ -24,7 +24,7 @@
                                     }
                                 },
                                 "relationship": "author_articles",
-                                "where": {
+                                "predicate": {
                                     "type": "and",
                                     "expressions": []
                                 }

--- a/ndc-reference/tests/query/table_argument_predicate/request.json
+++ b/ndc-reference/tests/query/table_argument_predicate/request.json
@@ -9,7 +9,7 @@
                 "column": "id"
             }
         },
-        "where": {
+        "predicate": {
             "type": "binary_comparison_operator",
             "column": {
                 "type": "column",
@@ -23,7 +23,7 @@
                             }
                         },
                         "relationship": "author_articles",
-                        "where": {
+                        "predicate": {
                             "type": "and",
                             "expressions": []
                         }

--- a/ndc-reference/tests/query/table_argument_unrelated_exists/request.json
+++ b/ndc-reference/tests/query/table_argument_unrelated_exists/request.json
@@ -9,7 +9,7 @@
                 "column": "id"
             }
         },
-        "where": {
+        "predicate": {
             "type": "exists",
             "in_collection": {
                 "type": "unrelated",
@@ -21,7 +21,7 @@
                 },
                 "collection": "articles_by_author"
             },
-            "where": {
+            "predicate": {
                 "type": "and",
                 "expressions": [
                     {

--- a/ndc-reference/tests/query/variables/request.json
+++ b/ndc-reference/tests/query/variables/request.json
@@ -13,7 +13,7 @@
                 "column": "title"
             }
         },
-        "where": {
+        "predicate": {
             "type": "binary_comparison_operator",
             "column": {
                 "type": "column",


### PR DESCRIPTION
Alternative to #86

Follow up to #84

This PR changes `where` keys to `predicate` in the connector IR

This is a breaking changes for the connector spec.

This PR also makes predicates optional in`PathElement` and `Expression::Exists`, to make it consistent with `Query`

Finally, this PR also removes redundant redefintions to make rust compile happily.