### PR TITLE
Use NestedField to request procedure result fields

### DIFF
--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -168,7 +168,7 @@ pub enum Type {
     Predicate {
         /// The object type name
         object_type_name: String,
-    }
+    },
 }
 // ANCHOR_END: Type
 
@@ -381,7 +381,7 @@ pub struct NestedArray {
 #[schemars(title = "NestedField")]
 pub enum NestedField {
     Object(NestedObject),
-    Array(NestedArray)
+    Array(NestedArray),
 }
 // ANCHOR_END: NestedField
 
@@ -396,7 +396,7 @@ pub enum Field {
         /// the caller can request a subset of the complete column data,
         /// by specifying fields to fetch here.
         /// If omitted, the column data will be fetched in full.
-        fields: Option<NestedField>
+        fields: Option<NestedField>,
     },
     Relationship {
         query: Box<Query>,
@@ -642,8 +642,8 @@ pub enum MutationOperation {
         name: String,
         /// Any named procedure arguments
         arguments: BTreeMap<String, serde_json::Value>,
-        /// The fields to return
-        fields: Option<IndexMap<String, Field>>,
+        /// The fields to return from the result, or null to return everything
+        fields: Option<NestedField>,
     },
 }
 // ANCHOR_END: MutationOperation
@@ -705,14 +705,13 @@ pub struct MutationResponse {
 // ANCHOR_END: MutationResponse
 
 // ANCHOR: MutationOperationResults
-#[skip_serializing_none]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema,
+)]
 #[schemars(title = "Mutation Operation Results")]
-pub struct MutationOperationResults {
-    /// The number of rows affected by the mutation operation
-    pub affected_rows: u32,
-    /// The rows affected by the mutation operation
-    pub returning: Option<Vec<IndexMap<String, RowFieldValue>>>,
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MutationOperationResults {
+    Procedure { result: serde_json::Value },
 }
 // ANCHOR_END: MutationOperationResults
 

--- a/ndc-client/tests/json_schema/mutation_request.jsonschema
+++ b/ndc-client/tests/json_schema/mutation_request.jsonschema
@@ -50,14 +50,61 @@
               "additionalProperties": true
             },
             "fields": {
-              "description": "The fields to return",
-              "type": [
-                "object",
-                "null"
-              ],
+              "description": "The fields to return from the result, or null to return everything",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NestedField"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "NestedField": {
+      "title": "NestedField",
+      "oneOf": [
+        {
+          "title": "NestedObject",
+          "type": "object",
+          "required": [
+            "fields",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "object"
+              ]
+            },
+            "fields": {
+              "type": "object",
               "additionalProperties": {
                 "$ref": "#/definitions/Field"
               }
+            }
+          }
+        },
+        {
+          "title": "NestedArray",
+          "type": "object",
+          "required": [
+            "fields",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "array"
+              ]
+            },
+            "fields": {
+              "$ref": "#/definitions/NestedField"
             }
           }
         }
@@ -123,52 +170,6 @@
               "additionalProperties": {
                 "$ref": "#/definitions/RelationshipArgument"
               }
-            }
-          }
-        }
-      ]
-    },
-    "NestedField": {
-      "title": "NestedField",
-      "oneOf": [
-        {
-          "title": "NestedObject",
-          "type": "object",
-          "required": [
-            "fields",
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "object"
-              ]
-            },
-            "fields": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/Field"
-              }
-            }
-          }
-        },
-        {
-          "title": "NestedArray",
-          "type": "object",
-          "required": [
-            "fields",
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "array"
-              ]
-            },
-            "fields": {
-              "$ref": "#/definitions/NestedField"
             }
           }
         }

--- a/ndc-client/tests/json_schema/mutation_response.jsonschema
+++ b/ndc-client/tests/json_schema/mutation_response.jsonschema
@@ -17,34 +17,24 @@
   "definitions": {
     "MutationOperationResults": {
       "title": "Mutation Operation Results",
-      "type": "object",
-      "required": [
-        "affected_rows"
-      ],
-      "properties": {
-        "affected_rows": {
-          "description": "The number of rows affected by the mutation operation",
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0
-        },
-        "returning": {
-          "description": "The rows affected by the mutation operation",
-          "type": [
-            "array",
-            "null"
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "result",
+            "type"
           ],
-          "items": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/definitions/RowFieldValue"
-            }
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "procedure"
+              ]
+            },
+            "result": true
           }
         }
-      }
-    },
-    "RowFieldValue": {
-      "title": "Row Field Value"
+      ]
     }
   }
 }

--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -1979,19 +1979,6 @@ fn execute_upsert_article(
             Ok(old_row_fields.0)
         })?
     })
-    
-    // let returning = old_row.map(|old_row| todo!()).transpose()?;
-    // Ok(models::MutationOperationResults::Procedure {
-    //     result: serde_json::to_value(returning).map_err(|_| {
-    //         (
-    //             StatusCode::INTERNAL_SERVER_ERROR,
-    //             Json(models::ErrorResponse {
-    //                 message: "cannot encode response".into(),
-    //                 details: serde_json::Value::Null,
-    //             }),
-    //         )
-    //     })?,
-    // })
 }
 // ANCHOR_END: execute_upsert_article
 // ANCHOR: execute_delete_articles

--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -1970,7 +1970,7 @@ fn execute_upsert_article(
                 Some(nested_field) => eval_nested_field(
                     collection_relationships,
                     &BTreeMap::new(),
-                    &state,
+                    state,
                     old_row_value,
                     nested_field,
                 ),

--- a/ndc-reference/tests/mutation/delete_articles/expected.json
+++ b/ndc-reference/tests/mutation/delete_articles/expected.json
@@ -1,15 +1,11 @@
 {
   "operation_results": [
     {
-      "affected_rows": 1,
-      "returning": [
+      "type": "procedure",
+      "result": [
         {
-          "__value": [
-            {
-              "id": 1,
-              "title": "The Next 700 Programming Languages"
-            }
-          ]
+          "idx": 1,
+          "title": "The Next 700 Programming Languages"
         }
       ]
     }

--- a/ndc-reference/tests/mutation/delete_articles/expected.json
+++ b/ndc-reference/tests/mutation/delete_articles/expected.json
@@ -4,7 +4,7 @@
       "type": "procedure",
       "result": [
         {
-          "idx": 1,
+          "id": 1,
           "title": "The Next 700 Programming Languages"
         }
       ]

--- a/ndc-reference/tests/mutation/delete_articles/request.json
+++ b/ndc-reference/tests/mutation/delete_articles/request.json
@@ -21,13 +21,19 @@
                 }
             },
             "fields": {
-                "id": {
-                    "type": "column",
-                    "column": "id"
-                },
-                "title": {
-                    "type": "column",
-                    "column": "title"
+                "type": "array",
+                "fields": {
+                    "type": "object",
+                    "fields": {
+                        "id": {
+                            "type": "column",
+                            "column": "id"
+                        },
+                        "title": {
+                            "type": "column",
+                            "column": "title"
+                        }
+                    }
                 }
             }
         }

--- a/ndc-reference/tests/mutation/upsert_article/expected.json
+++ b/ndc-reference/tests/mutation/upsert_article/expected.json
@@ -1,12 +1,8 @@
 {
   "operation_results": [
     {
-      "affected_rows": 1,
-      "returning": [
-        {
-          "__value": null
-        }
-      ]
+      "type": "procedure",
+      "result": null
     }
   ]
 }

--- a/ndc-reference/tests/mutation/upsert_article/request.json
+++ b/ndc-reference/tests/mutation/upsert_article/request.json
@@ -13,9 +13,12 @@
                 }
             },
             "fields": {
-                "id": {
-                    "type": "column",
-                    "column": "id"
+                "type": "object",
+                "fields": {
+                    "id": {
+                        "type": "column",
+                        "column": "id"
+                    }
                 }
             }
         }

--- a/ndc-reference/tests/mutation/upsert_article_with_relationship/expected.json
+++ b/ndc-reference/tests/mutation/upsert_article_with_relationship/expected.json
@@ -1,22 +1,18 @@
 {
   "operation_results": [
     {
-      "affected_rows": 1,
-      "returning": [
-        {
-          "__value": {
-            "id": 2,
-            "author": {
-              "rows": [
-                {
-                  "first_name": "John",
-                  "last_name": "Hughes"
-                }
-              ]
+      "type": "procedure",
+      "result": {
+        "id": 2,
+        "author": {
+          "rows": [
+            {
+              "first_name": "John",
+              "last_name": "Hughes"
             }
-          }
+          ]
         }
-      ]
+      }
     }
   ]
 }

--- a/ndc-reference/tests/mutation/upsert_article_with_relationship/request.json
+++ b/ndc-reference/tests/mutation/upsert_article_with_relationship/request.json
@@ -13,23 +13,26 @@
                 }
             },
             "fields": {
-                "id": {
-                    "type": "column",
-                    "column": "id"
-                },
-                "author": {
-                    "type": "relationship",
-                    "arguments": {},
-                    "relationship": "article_author",
-                    "query": {
-                        "fields": {
-                            "first_name": {
-                                "type": "column",
-                                "column": "first_name"
-                            },
-                            "last_name": {
-                                "type": "column",
-                                "column": "last_name"
+                "type": "object",
+                "fields": {
+                    "id": {
+                        "type": "column",
+                        "column": "id"
+                    },
+                    "author": {
+                        "type": "relationship",
+                        "arguments": {},
+                        "relationship": "article_author",
+                        "query": {
+                            "fields": {
+                                "first_name": {
+                                    "type": "column",
+                                    "column": "first_name"
+                                },
+                                "last_name": {
+                                    "type": "column",
+                                    "column": "last_name"
+                                }
                             }
                         }
                     }

--- a/specification/src/specification/mutations/procedures.md
+++ b/specification/src/specification/mutations/procedures.md
@@ -4,6 +4,8 @@ A procedure which is [described in the schema](../schema/procedures.md) can be i
 
 The operation should specify the procedure name, any arguments, and a list of [`Field`](../../reference/types.md#field)s to be returned.
 
+_Note_: just as for [functions](../queries/functions.md), fields to return can include [relationships](../queries/relationships.md) or [nested fields](../queries/field-selection.md#nested-fields). However, unlike functions, procedures do not need to wrap their result in a `__value` field, so top-level fields can be extracted without use of nested field queries.
+
 ## Requirements
 
 - The `affected_rows` field in the corresponding [`MutationOperationResults`](../../reference/types.md#mutationoperationresults) structure should indicate the number of rows in the data source which were modified as a result of the operation.

--- a/specification/src/tutorial/mutations/procedures.md
+++ b/specification/src/tutorial/mutations/procedures.md
@@ -22,9 +22,7 @@ The `execute_upsert_article` function reads the `article` argument from the `arg
 
 It then inserts or updates that article in the application state, depending on whether or not an article with that `id` already exists or not.
 
-Finally, it delegates to the `eval_field` function to evaluate each requested field in turn, and returns a single row and column (named `__value`) containing the result.
-
-`affected_rows` contains `1` to indicate that one row of data was affected.
+Finally, it delegates to the `eval_nested_field` function to evaluate any nested fields, and returns the selected fields in the result:
 
 ```rust,no_run,noplayground
 {{#include ../../../../ndc-reference/bin/reference/main.rs:execute_upsert_article}}
@@ -40,7 +38,7 @@ The `execute_delete_articles` function reads the `where` argument from the `argu
 
 It then deletes all articles in the application state which match the predicate, and returns a list of the deleted rows.
 
-The function  delegates to the `eval_field` function to evaluate each requested field in turn, and returns a single row and column (named `__value`) containing the result.
+This function delegates to the `eval_nested_field` function to evaluate any nested fields, and returns the selected fields in the result:
 
 ```rust,no_run,noplayground
 {{#include ../../../../ndc-reference/bin/reference/main.rs:execute_delete_articles}}


### PR DESCRIPTION
This is the current `MutationOperationResults`:

```rust
pub struct MutationOperationResults {
    /// The number of rows affected by the mutation operation
    pub affected_rows: u32,
    /// The rows affected by the mutation operation
    pub returning: Option<Vec<IndexMap<String, RowFieldValue>>>,
}
```

Note we always return an optional list of rows.

However, this is the corresponding mutation request:

```rust
pub enum MutationOperation {
    Procedure {
        /// The name of a procedure
        name: String,
        /// Any named procedure arguments
        arguments: BTreeMap<String, serde_json::Value>,
        /// The fields to return
        fields: Option<IndexMap<String, Field>>,
    },
}
```

Fields is optional, because the result type might be a scalar.

Currently, the reference implementation packs the result into a `__value` field just like for functions, but this is a hack because `__value` was there to make functions work like collections, and there's no such constraint for procedures. The calling convention for procedures can be simpler.

It doesn't make sense to return a list of rows since we only have procedures.

## Proposal

The return type continues to be anything, so we use `NestedField` to query it (`NestedField` being the way we query single column values of arbitrary type):

```rust
pub enum MutationOperation {
    Procedure {
        /// The name of a procedure
        name: String,
        /// Any named procedure arguments
        arguments: BTreeMap<String, serde_json::Value>,
        /// The fields to return from the result, or null to return everything
        fields: Option<NestedField>,
    },
}

pub struct MutationOperationResults {
    pub result: serde_json::Value,
}
```

Basically we keep things as-is from a query expressiveness point of view, but do away with the `__value` hack.

The only thing we can't express (which would be dubious today anyway) is a relationship from a scalar return type.

### Alternative Design

Force procedures to return an object type:

```rust
pub enum MutationOperation {
    Procedure {
        /// The name of a procedure
        name: String,
        /// Any named procedure arguments
        arguments: BTreeMap<String, serde_json::Value>,
        /// The fields to return
        fields: IndexMap<String, Field>
    },
}

pub struct MutationOperationResults {
    pub result: Row,
}
```