### PR TITLE
healthz/204 -> health/200

### DIFF
--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -130,7 +130,7 @@ async fn main() {
     let app_state = Arc::new(Mutex::new(init_app_state()));
 
     let app = Router::new()
-        .route("/healthz", get(get_healthz))
+        .route("/health", get(get_health))
         .route("/metrics", get(get_metrics))
         .route("/capabilities", get(get_capabilities))
         .route("/schema", get(get_schema))
@@ -152,8 +152,8 @@ async fn main() {
 }
 // ANCHOR_END: main
 // ANCHOR: health
-async fn get_healthz() -> StatusCode {
-    StatusCode::NO_CONTENT
+async fn get_health() -> StatusCode {
+    StatusCode::OK
 }
 // ANCHOR_END: health
 // ANCHOR: metrics

--- a/specification/src/specification/health.md
+++ b/specification/src/specification/health.md
@@ -5,11 +5,11 @@ Data connectors should provide a __health endpoint__ which can be used to indica
 ## Request
 
 ```
-GET /healthz
+GET /health
 ```
 
 ## Response
 
-If the data connector is available and ready to accept requests, then the health endpoint should return status code `204 No Content`.
+If the data connector is available and ready to accept requests, then the health endpoint should return status code `200 OK`.
 
 Otherwise, it should ideally return a status code `503 Service Unavailable`, or some other appropriate HTTP error code.

--- a/specification/src/tutorial/health.md
+++ b/specification/src/tutorial/health.md
@@ -2,7 +2,7 @@
 
 ## Service Health
 
-The `/healthz` endpoint has nothing to check, because the reference implementation does not need to connect to any other services. Therefore, once the reference implementation is running, it can always report a healthy status:
+The `/health` endpoint has nothing to check, because the reference implementation does not need to connect to any other services. Therefore, once the reference implementation is running, it can always report a healthy status:
 
 ```rust,no_run,noplayground
 {{#include ../../../ndc-reference/bin/reference/main.rs:health}}


### PR DESCRIPTION
Some cloud services require the health check endpoint to return `200 OK`. The `204 (No Content)` status can be (incorrectly) interpreted as failure.

This changes to require and use the `200 OK` status code to avoid unexpected issues.