### PR TITLE
reference: fix inconsistent latest_article schema

### DIFF
--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -574,11 +574,9 @@ async fn get_schema() -> Json<models::SchemaResponse> {
     let latest_article_function = models::FunctionInfo {
         name: "latest_article".into(),
         description: Some("Get the most recent article".into()),
-        result_type: models::Type::Array {
-            element_type: Box::new(models::Type::Nullable {
-                underlying_type: Box::new(models::Type::Named {
-                    name: "article".into(),
-                }),
+        result_type: models::Type::Nullable {
+            underlying_type: Box::new(models::Type::Named {
+                name: "article".into(),
             }),
         },
         arguments: BTreeMap::new(),

--- a/ndc-reference/tests/schema/expected.json
+++ b/ndc-reference/tests/schema/expected.json
@@ -215,7 +215,9 @@
       "type": "article",
       "uniqueness_constraints": {
         "ArticleByID": {
-          "unique_columns": ["id"]
+          "unique_columns": [
+            "id"
+          ]
         }
       },
       "foreign_keys": {
@@ -234,7 +236,9 @@
       "type": "author",
       "uniqueness_constraints": {
         "AuthorByID": {
-          "unique_columns": ["id"]
+          "unique_columns": [
+            "id"
+          ]
         }
       },
       "foreign_keys": {}
@@ -246,7 +250,9 @@
       "type": "institution",
       "uniqueness_constraints": {
         "InstitutionByID": {
-          "unique_columns": ["id"]
+          "unique_columns": [
+            "id"
+          ]
         }
       },
       "foreign_keys": {}

--- a/ndc-reference/tests/schema/expected.json
+++ b/ndc-reference/tests/schema/expected.json
@@ -215,9 +215,7 @@
       "type": "article",
       "uniqueness_constraints": {
         "ArticleByID": {
-          "unique_columns": [
-            "id"
-          ]
+          "unique_columns": ["id"]
         }
       },
       "foreign_keys": {
@@ -236,9 +234,7 @@
       "type": "author",
       "uniqueness_constraints": {
         "AuthorByID": {
-          "unique_columns": [
-            "id"
-          ]
+          "unique_columns": ["id"]
         }
       },
       "foreign_keys": {}
@@ -250,9 +246,7 @@
       "type": "institution",
       "uniqueness_constraints": {
         "InstitutionByID": {
-          "unique_columns": [
-            "id"
-          ]
+          "unique_columns": ["id"]
         }
       },
       "foreign_keys": {}
@@ -291,13 +285,10 @@
       "description": "Get the most recent article",
       "arguments": {},
       "result_type": {
-        "type": "array",
-        "element_type": {
-          "type": "nullable",
-          "underlying_type": {
-            "type": "named",
-            "name": "article"
-          }
+        "type": "nullable",
+        "underlying_type": {
+          "type": "named",
+          "name": "article"
         }
       }
     }


### PR DESCRIPTION
The PR fixes the inconsistency between the schema and implementation of [latest_article function](https://github.com/hasura/ndc-spec/blob/590edfcee075de602f0e8f17ae7d575da5e82289/ndc-reference/bin/reference/main.rs#L739).  The result  is an object ([expected.json](https://github.com/hasura/ndc-spec/blob/main/ndc-reference/tests/query/get_max_article/expected.json)), but the schema is an array. 