### PR TITLE
Add TestGenerationConfiguration and CLI options

### DIFF
--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -2289,6 +2289,7 @@ mod tests {
             let configuration = TestConfiguration {
                 seed: None,
                 snapshots_dir: None,
+                gen_config: Default::default(),
             };
             let connector = Reference {
                 state: init_app_state(),

--- a/ndc-test/src/configuration.rs
+++ b/ndc-test/src/configuration.rs
@@ -4,4 +4,22 @@ use std::path::PathBuf;
 pub struct TestConfiguration {
     pub seed: Option<[u8; 32]>,
     pub snapshots_dir: Option<PathBuf>,
+    pub gen_config: TestGenerationConfiguration,
+}
+
+#[derive(Debug)]
+pub struct TestGenerationConfiguration {
+    pub test_cases: u32,
+    pub sample_size: u32,
+    pub max_limit: u32,
+}
+
+impl Default for TestGenerationConfiguration {
+    fn default() -> Self {
+        Self {
+            test_cases: 10,
+            sample_size: 10,
+            max_limit: 10,
+        }
+    }
 }

--- a/ndc-test/src/lib.rs
+++ b/ndc-test/src/lib.rs
@@ -55,9 +55,13 @@ pub async fn test_connector<C: Connector, R: Reporter>(
     };
 
     let _ = match &configuration.snapshots_dir {
-        None => test_cases::run_all_tests(connector, reporter, &mut rng).await,
+        None => {
+            test_cases::run_all_tests(&configuration.gen_config, connector, reporter, &mut rng)
+                .await
+        }
         Some(snapshot_path) => {
             test_cases::run_all_tests(
+                &configuration.gen_config,
                 &SnapshottingConnector {
                     snapshot_path,
                     connector,

--- a/ndc-test/src/test_cases/mod.rs
+++ b/ndc-test/src/test_cases/mod.rs
@@ -2,6 +2,7 @@ mod capabilities;
 mod query;
 mod schema;
 
+use crate::configuration::TestGenerationConfiguration;
 use crate::connector::Connector;
 use crate::nest;
 use crate::reporter::Reporter;
@@ -9,6 +10,7 @@ use crate::reporter::Reporter;
 use rand::rngs::SmallRng;
 
 pub async fn run_all_tests<C: Connector, R: Reporter>(
+    gen_config: &TestGenerationConfiguration,
     connector: &C,
     reporter: &mut R,
     rng: &mut SmallRng,
@@ -22,7 +24,7 @@ pub async fn run_all_tests<C: Connector, R: Reporter>(
     })?;
 
     nest!("Query", reporter, {
-        query::test_query(connector, reporter, &capabilities, &schema, rng)
+        query::test_query(gen_config, connector, reporter, &capabilities, &schema, rng)
     });
 
     Some(())

--- a/ndc-test/src/test_cases/query/aggregates/mod.rs
+++ b/ndc-test/src/test_cases/query/aggregates/mod.rs
@@ -3,12 +3,14 @@ use crate::error::Error;
 use crate::error::Result;
 use crate::reporter::Reporter;
 use crate::test;
+use crate::configuration::TestGenerationConfiguration;
 
 use indexmap::IndexMap;
 use ndc_client::models;
 use std::collections::BTreeMap;
 
 pub async fn test_aggregate_queries<C: Connector, R: Reporter>(
+    gen_config: &TestGenerationConfiguration,
     connector: &C,
     reporter: &mut R,
     schema: &models::SchemaResponse,
@@ -21,19 +23,20 @@ pub async fn test_aggregate_queries<C: Connector, R: Reporter>(
     let total_count = test!(
         "star_count",
         reporter,
-        test_star_count_aggregate(connector, collection_info)
+        test_star_count_aggregate(gen_config, connector, collection_info)
     )?;
 
     let _ = test!(
         "column_count",
         reporter,
-        test_column_count_aggregate(connector, collection_info, collection_type, total_count)
+        test_column_count_aggregate(gen_config, connector, collection_info, collection_type, total_count)
     );
 
     Some(())
 }
 
 pub async fn test_star_count_aggregate<C: Connector>(
+    gen_config: &TestGenerationConfiguration,
     connector: &C,
     collection_info: &models::CollectionInfo,
 ) -> Result<u64> {
@@ -43,7 +46,7 @@ pub async fn test_star_count_aggregate<C: Connector>(
         query: models::Query {
             aggregates: Some(aggregates),
             fields: None,
-            limit: Some(10),
+            limit: Some(gen_config.max_limit),
             offset: None,
             order_by: None,
             predicate: None,
@@ -71,6 +74,7 @@ pub async fn test_star_count_aggregate<C: Connector>(
 }
 
 pub async fn test_column_count_aggregate<C: Connector>(
+    gen_config: &TestGenerationConfiguration,
     connector: &C,
     collection_info: &models::CollectionInfo,
     collection_type: &models::ObjectType,
@@ -97,7 +101,7 @@ pub async fn test_column_count_aggregate<C: Connector>(
         query: models::Query {
             aggregates: Some(aggregates),
             fields: None,
-            limit: Some(10),
+            limit: Some(gen_config.max_limit),
             offset: None,
             order_by: None,
             predicate: None,

--- a/ndc-test/src/test_cases/query/mod.rs
+++ b/ndc-test/src/test_cases/query/mod.rs
@@ -6,6 +6,7 @@ mod common;
 mod context;
 mod expectations;
 
+use crate::configuration::TestGenerationConfiguration;
 use crate::connector::Connector;
 use crate::nest;
 use crate::reporter::Reporter;
@@ -14,6 +15,7 @@ use ndc_client::models;
 use rand::rngs::SmallRng;
 
 pub async fn test_query<C: Connector, R: Reporter>(
+    gen_config: &TestGenerationConfiguration,
     connector: &C,
     reporter: &mut R,
     capabilities: &models::CapabilitiesResponse,
@@ -26,6 +28,7 @@ pub async fn test_query<C: Connector, R: Reporter>(
                 if collection_info.arguments.is_empty() {
                     nest!("Simple queries", reporter, {
                         simple_queries::test_simple_queries(
+                            gen_config,
                             connector,
                             reporter,
                             rng,
@@ -37,6 +40,7 @@ pub async fn test_query<C: Connector, R: Reporter>(
                     if capabilities.capabilities.relationships.is_some() {
                         nest!("Relationship queries", reporter, {
                             relationships::test_relationship_queries(
+                                gen_config,
                                 connector,
                                 reporter,
                                 schema,
@@ -47,6 +51,7 @@ pub async fn test_query<C: Connector, R: Reporter>(
 
                     nest!("Aggregate queries", reporter, {
                         aggregates::test_aggregate_queries(
+                            gen_config,
                             connector,
                             reporter,
                             schema,

--- a/ndc-test/src/test_cases/query/relationships/mod.rs
+++ b/ndc-test/src/test_cases/query/relationships/mod.rs
@@ -5,10 +5,12 @@ use crate::error::Error;
 use crate::error::Result;
 use crate::reporter::Reporter;
 use crate::{nest, test};
+use crate::configuration::TestGenerationConfiguration;
 
 use ndc_client::models::{self};
 
 pub async fn test_relationship_queries<C: Connector, R: Reporter>(
+    gen_config: &TestGenerationConfiguration,
     connector: &C,
     reporter: &mut R,
     schema: &models::SchemaResponse,
@@ -29,6 +31,7 @@ pub async fn test_relationship_queries<C: Connector, R: Reporter>(
                     "Object relationship",
                     reporter,
                     select_top_n_using_foreign_key(
+                        gen_config,
                         connector,
                         collection_type,
                         collection_info,
@@ -42,6 +45,7 @@ pub async fn test_relationship_queries<C: Connector, R: Reporter>(
                     "Array relationship",
                     reporter,
                     select_top_n_using_foreign_key_as_array_relationship(
+                        gen_config,
                         connector,
                         collection_type,
                         collection_info,
@@ -61,6 +65,7 @@ pub async fn test_relationship_queries<C: Connector, R: Reporter>(
 }
 
 async fn select_top_n_using_foreign_key<C: Connector>(
+    gen_config: &TestGenerationConfiguration,
     connector: &C,
     collection_type: &models::ObjectType,
     collection_info: &models::CollectionInfo,
@@ -94,7 +99,7 @@ async fn select_top_n_using_foreign_key<C: Connector>(
                 query: Box::new(models::Query {
                     aggregates: None,
                     fields: Some(other_fields.clone()),
-                    limit: Some(10),
+                    limit: Some(gen_config.max_limit),
                     offset: None,
                     order_by: None,
                     predicate: None,
@@ -109,7 +114,7 @@ async fn select_top_n_using_foreign_key<C: Connector>(
             query: models::Query {
                 aggregates: None,
                 fields: Some(fields.clone()),
-                limit: Some(10),
+                limit: Some(gen_config.max_limit),
                 offset: None,
                 order_by: None,
                 predicate: None,
@@ -138,6 +143,7 @@ async fn select_top_n_using_foreign_key<C: Connector>(
 }
 
 async fn select_top_n_using_foreign_key_as_array_relationship<C: Connector>(
+    gen_config: &TestGenerationConfiguration,
     connector: &C,
     collection_type: &models::ObjectType,
     collection_info: &models::CollectionInfo,
@@ -171,7 +177,7 @@ async fn select_top_n_using_foreign_key_as_array_relationship<C: Connector>(
                 query: Box::new(models::Query {
                     aggregates: None,
                     fields: Some(fields.clone()),
-                    limit: Some(10),
+                    limit: Some(gen_config.max_limit),
                     offset: None,
                     order_by: None,
                     predicate: None,
@@ -192,7 +198,7 @@ async fn select_top_n_using_foreign_key_as_array_relationship<C: Connector>(
             query: models::Query {
                 aggregates: None,
                 fields: Some(other_fields.clone()),
-                limit: Some(10),
+                limit: Some(gen_config.max_limit),
                 offset: None,
                 order_by: None,
                 predicate: None,


### PR DESCRIPTION
Makes it possible to configure some aspects of testing via the CLI:

```
Usage: ndc-test test [OPTIONS] --endpoint <ENDPOINT>

Options:
      --endpoint <ENDPOINT>   The NDC endpoint to test
      --seed <SEED>           a 32-byte string with which to initialize the RNG
      --snapshots-dir <PATH>  the directory used to store snapshot files
      --test-cases <COUNT>    the number of test cases to generate per scenario [default: 10]
      --sample-size <COUNT>   the number of example rows to fetch from each collection [default: 10]
      --max-limit <COUNT>     the maximum number of rows to fetch per test query [default: 10]
  -h, --help                  Print help
  -V, --version               Print version
```