### PR TITLE
ndc-test: fix nulls in sampled data

### DIFF
--- a/ndc-test/src/test_cases/query/context.rs
+++ b/ndc-test/src/test_cases/query/context.rs
@@ -28,10 +28,12 @@ pub fn make_context(
         }
 
         for (field_name, field_value) in row {
-            values
-                .entry(field_name.clone())
-                .or_insert(vec![])
-                .push(field_value.0);
+            if !field_value.0.is_null() {
+                values
+                    .entry(field_name.clone())
+                    .or_insert(vec![])
+                    .push(field_value.0);
+            }
         }
     }
 


### PR DESCRIPTION
This got lost in the recent refactor, but it's important that we don't include nulls in the sampled data.