### PR TITLE
RFC: equality in relationships

### DIFF
--- a/ndc-test/src/error.rs
+++ b/ndc-test/src/error.rs
@@ -46,6 +46,8 @@ pub enum Error {
     MissingField(String),
     #[error("field {0} was not expected in response")]
     UnexpectedField(String),
+    #[error("scalar type {0} has multiple equality operators")]
+    MultipleEqualityOperators(String),
     #[error("error response from connector: {0:?}")]
     ConnectorError(ndc_client::models::ErrorResponse),
     #[error("cannot open snapshot file: {0:?}")]

--- a/ndc-test/src/test_cases/query/context.rs
+++ b/ndc-test/src/test_cases/query/context.rs
@@ -17,7 +17,7 @@ pub struct Context<'a> {
 pub fn make_context(
     collection_type: &models::ObjectType,
     rows: Vec<IndexMap<String, models::RowFieldValue>>,
-) -> Result<Option<Context>> {
+) -> Result<Option<Context<'_>>> {
     let mut values = BTreeMap::new();
 
     for row in rows {

--- a/ndc-test/src/test_cases/query/mod.rs
+++ b/ndc-test/src/test_cases/query/mod.rs
@@ -26,7 +26,7 @@ pub async fn test_query<C: Connector, R: Reporter>(
         nest!(collection_info.name.as_str(), reporter, {
             async {
                 if collection_info.arguments.is_empty() {
-                    nest!("Simple queries", reporter, {
+                    let context = nest!("Simple queries", reporter, {
                         simple_queries::test_simple_queries(
                             gen_config,
                             connector,
@@ -35,7 +35,7 @@ pub async fn test_query<C: Connector, R: Reporter>(
                             schema,
                             collection_info,
                         )
-                    });
+                    })?;
 
                     if capabilities.capabilities.relationships.is_some() {
                         nest!("Relationship queries", reporter, {
@@ -45,6 +45,7 @@ pub async fn test_query<C: Connector, R: Reporter>(
                                 reporter,
                                 schema,
                                 collection_info,
+                                &context,
                                 rng,
                             )
                         });
@@ -62,6 +63,8 @@ pub async fn test_query<C: Connector, R: Reporter>(
                 } else {
                     eprintln!("Skipping parameterized collection {}", collection_info.name);
                 }
+
+                Some(())
             }
         });
     }

--- a/ndc-test/src/test_cases/query/relationships/mod.rs
+++ b/ndc-test/src/test_cases/query/relationships/mod.rs
@@ -18,6 +18,7 @@ pub async fn test_relationship_queries<C: Connector, R: Reporter>(
     reporter: &mut R,
     schema: &models::SchemaResponse,
     collection_info: &models::CollectionInfo,
+    context: &Option<super::context::Context<'_>>,
     rng: &mut SmallRng,
 ) -> Option<()> {
     let collection_type = schema
@@ -60,6 +61,23 @@ pub async fn test_relationship_queries<C: Connector, R: Reporter>(
                         rng,
                     )
                 );
+
+                if let Some(context) = context {
+                    let _ = test!(
+                        "Exists",
+                        reporter,
+                        select_top_n_using_foreign_key_exists(
+                            gen_config,
+                            connector,
+                            collection_info,
+                            schema,
+                            foreign_key_name,
+                            foreign_key,
+                            context,
+                            rng,
+                        )
+                    );
+                };
 
                 Some(())
             }
@@ -142,6 +160,87 @@ async fn select_top_n_using_foreign_key<C: Connector>(
         let response = connector.query(query_request.clone()).await?;
 
         validate_response(&query_request, &response)?;
+    } else {
+        eprintln!("Skipping parameterized relationship {}", foreign_key_name);
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn select_top_n_using_foreign_key_exists<C: Connector>(
+    gen_config: &TestGenerationConfiguration,
+    connector: &C,
+    collection_info: &models::CollectionInfo,
+    schema: &models::SchemaResponse,
+    foreign_key_name: &str,
+    foreign_key: &models::ForeignKeyConstraint,
+    context: &super::context::Context<'_>,
+    rng: &mut SmallRng,
+) -> Result<()> {
+    let other_collection = schema
+        .collections
+        .iter()
+        .find(|c| c.name == foreign_key.foreign_collection)
+        .ok_or(Error::CollectionIsNotDefined(
+            foreign_key.foreign_collection.clone(),
+        ))?;
+
+    let other_collection_type = schema
+        .object_types
+        .get(other_collection.collection_type.as_str())
+        .ok_or(Error::CollectionTypeIsNotDefined(
+            other_collection.collection_type.clone(),
+        ))?;
+
+    let other_fields = super::common::select_all_columns(other_collection_type);
+
+    let mut column_mapping = BTreeMap::new();
+
+    for (column, other_column) in foreign_key.column_mapping.iter() {
+        column_mapping.insert(other_column.clone(), column.clone());
+    }
+
+    if other_collection.arguments.is_empty() {
+        for _ in 0..gen_config.test_cases.max(1) {
+            let predicate = super::simple_queries::predicates::make_predicate(
+                gen_config, schema, context, rng,
+            )?;
+            let predicate = predicate.map(|e| e.expr);
+
+            let query_request = models::QueryRequest {
+                collection: foreign_key.foreign_collection.clone(),
+                query: models::Query {
+                    aggregates: None,
+                    fields: Some(other_fields.clone()),
+                    limit: Some(gen_config.max_limit),
+                    offset: None,
+                    order_by: None,
+                    predicate: Some(models::Expression::Exists {
+                        in_collection: models::ExistsInCollection::Related {
+                            relationship: "__array_relationship".into(),
+                            arguments: BTreeMap::new(),
+                        },
+                        predicate: predicate.map(Box::new),
+                    }),
+                },
+                arguments: BTreeMap::new(),
+                collection_relationships: BTreeMap::from_iter([(
+                    "__array_relationship".into(),
+                    models::Relationship {
+                        column_mapping: column_mapping.clone(),
+                        relationship_type: models::RelationshipType::Array,
+                        target_collection: collection_info.name.clone(),
+                        arguments: BTreeMap::new(),
+                    },
+                )]),
+                variables: None,
+            };
+
+            let response = connector.query(query_request.clone()).await?;
+
+            validate_response(&query_request, &response)?;
+        }
     } else {
         eprintln!("Skipping parameterized relationship {}", foreign_key_name);
     }

--- a/ndc-test/src/test_cases/query/simple_queries/mod.rs
+++ b/ndc-test/src/test_cases/query/simple_queries/mod.rs
@@ -1,5 +1,5 @@
-mod predicates;
-mod sorting;
+pub mod predicates;
+pub mod sorting;
 
 use std::collections::BTreeMap;
 
@@ -16,14 +16,14 @@ use rand::rngs::SmallRng;
 
 use super::validate::{expect_single_rows, validate_response};
 
-pub async fn test_simple_queries<C: Connector, R: Reporter>(
+pub async fn test_simple_queries<'a, 'b, C: Connector, R: Reporter>(
     gen_config: &TestGenerationConfiguration,
     connector: &C,
     reporter: &mut R,
     rng: &mut SmallRng,
-    schema: &models::SchemaResponse,
-    collection_info: &models::CollectionInfo,
-) -> Option<()> {
+    schema: &'a models::SchemaResponse,
+    collection_info: &'a models::CollectionInfo,
+) -> Option<Option<super::context::Context<'a>>> {
     let collection_type = schema
         .object_types
         .get(collection_info.collection_type.as_str())?;
@@ -46,7 +46,7 @@ pub async fn test_simple_queries<C: Connector, R: Reporter>(
         predicates::test_predicates(
             gen_config,
             connector,
-            context,
+            &context,
             schema,
             rng,
             collection_type,
@@ -65,7 +65,9 @@ pub async fn test_simple_queries<C: Connector, R: Reporter>(
             collection_type,
             collection_info
         )
-    )
+    );
+
+    Some(context)
 }
 
 async fn test_select_top_n_rows<C: Connector>(

--- a/ndc-test/src/test_cases/query/simple_queries/predicates.rs
+++ b/ndc-test/src/test_cases/query/simple_queries/predicates.rs
@@ -13,7 +13,7 @@ use rand::Rng;
 pub async fn test_predicates<C: Connector>(
     gen_config: &TestGenerationConfiguration,
     connector: &C,
-    context: Option<super::super::context::Context<'_>>,
+    context: &Option<super::super::context::Context<'_>>,
     schema: &models::SchemaResponse,
     rng: &mut SmallRng,
     collection_type: &models::ObjectType,
@@ -21,7 +21,7 @@ pub async fn test_predicates<C: Connector>(
 ) -> Result<()> {
     if let Some(context) = context {
         for _ in 0..gen_config.test_cases.max(1) {
-            if let Some(predicate) = make_predicate(gen_config, schema, &context, rng)? {
+            if let Some(predicate) = make_predicate(gen_config, schema, context, rng)? {
                 test_select_top_n_rows_with_predicate(
                     gen_config,
                     connector,

--- a/rfcs/0006-equality.md
+++ b/rfcs/0006-equality.md
@@ -25,9 +25,29 @@ But when we evaluate the predicate, we do so on `albums`: we first fetch a tenta
 
 So here, we have two notions of equality, and we expect them to generate the same rows. More specifically, we expect the predicate and the relationship to be compatible in the sense that any artist rows fetched via the relationship should match the predicate.
 
-## Options
+## Proposal
 
-### A - Specify which equality in metadata
+- We only allow a single equality operator per scalar type in the NDC response.
+  - It would be an error for the NDC schema response to contain multiple equality operators.
+- We add requirements to the specification to explain that equality operators are required to be definitional/syntactic.
+  - We can require that a single where clause with an equality predicate to return the provided value verbatim in the response JSON for the same column. We can call this syntactic equality.
+  - Alternatively, we could require substituting equals-for-equals in requests to give equal responses, but this is probably harder to test, and it's not clear that this equality is always strong enough to guarantee what we want for remote relationships.
+
+### Pros
+
+- No changes needed to existing connectors right now.
+
+### Cons
+
+- Now we can't use alternative equality operators in relationship definitions.
+  - We could support this later
+- Some types don't have a valid syntactic equality (e.g. `citext`) so we wouldn't be able to define any PK lookups or relationships against columns with those types.
+- Can't test non-equals operators
+  - We could add a "weak-equals" operator type ("equivalence") to support this.
+
+## Alternatives Considered
+
+### Specify which equality in metadata
 
 E.g. for a local relationship, we could define which equality we wanted to use for each column in the column mapping:
 
@@ -63,7 +83,7 @@ For remote relationships, we would have to require `operator` to be defined on `
 - No good way for tooling to generate the operator fields, since it won't know which equality to choose
 - Too verbose possibly
 
-### B - Specify which equality in the NDC schema
+### Specify which equality in the NDC schema
 
 The NDC schema could contain multiple equality operators per scalar type, but identify syntactic or definitional equality separately in the response, for use in object lookups or relationships:
 
@@ -102,9 +122,9 @@ Note: `"syntactic_equality": "eq"` above.
 - Breaking change to NDC
 - Can't use non-definitional equality in relationship definitions
 
-### C - Combination of options A and B
+### Both of the above
 
-Specify the equality in metadata, like option A, but also identify the definitional equality in the NDC schema, if it exists, to assist tooling in generating the metadata.
+Specify the equality in metadata, but also identify the definitional equality in the NDC schema, if it exists, to assist tooling in generating the metadata.
 
 This combines some of the pros and cons of those options. Metadata only needs to change if the user wants to use a custom equality operator for some reason, tooling can work automatically, but there is a breaking change to NDC.
 
@@ -115,26 +135,3 @@ This combines some of the pros and cons of those options. Metadata only needs to
 #### Cons
 
 - Breaking change to NDC
-
-### D - Only allow a single equality operator
-
-- It would be an error for the NDC schema response to contain multiple equality operators.
-- We add requirements to the specification to explain that equality operators are required to be definitional/syntactic. We can capture this in a couple of ways:
-  - (Definitional equality) We can require substituting equals-for-equals in requests to give equal responses
-  - (Syntactic equality) We can require that a single where clause with an equality predicate to return the provided value verbatim in the response JSON for the same column. This is probably easier to test.
-
-#### Pros
-
-- No changes needed to existing connectors
-
-#### Cons
-
-- Now we can't use alternative equality operators in relationship definitions.
-  - We could support this later
-- Some types don't have a valid definitional/syntactic equality (e.g. `citext`) so we wouldn't be able to define any PK lookups or relationships against columns with those types.
-- Can't test non-equals operators
-  - We could add a "weak-equals" operator type ("equivalence") to support this.
-
-## Proposal
-
-Currently we are leaning towards option D because it's non-breaking, but we might want to consider other options in the next round of breaking changes.

--- a/rfcs/0006-equality.md
+++ b/rfcs/0006-equality.md
@@ -1,0 +1,140 @@
+# Equality in Relationships
+
+## Purpose
+
+NDC identifies equality comparison operators via a `type` field which can be set to `Equals`. If an operator has this type, it accepts an argument of the same type as the field itself, and is expected to be an equivalence relation (reflexive, symmetric, transitive). It can be tested using `ndc-test`, since we can generate its arguments, and we know what to expect in the response.
+
+However, equality predicates in NDC are too loosely-specified. We currently allow multiple equality predicates per scalar type, to support cases like text which have multiple valid equalities (e.g. case-sensitive vs. case-insensitive). However, in the case of a primary key lookup (for example), which equality should be used? In case of a relationship, which equality should be used to implement the column mapping lookups? In these cases, a reasonable answer might be "this should be specified by the configuration of the caller", but it gets more complicated in the case of a remote relationship predicate.
+
+Consider something like
+
+```graphql
+albums(where: { artist { name: “AC/DC” } }) { 
+  title 
+  artist { 
+    name
+  } 
+}
+```
+
+And suppose that `albums` and `artists` are in different data sources.
+
+When we evaluate the `artist` field, we might generate a query with variables, and pass a list of `artist_id` values. Each `artist_id` value is used in an equality predicate to fetch the corresponding `artist`. Equality is interpreted in the target data source, that is, the one containing `artists`.
+
+But when we evaluate the predicate, we do so on `albums`: we first fetch a tentative set of artist rows by testing the name property on the target database, and then test for equality of the `artist_id` foreign key on the `albums` table of the source data source.
+
+So here, we have two notions of equality, and we expect them to generate the same rows. More specifically, we expect the predicate and the relationship to be compatible in the sense that any artist rows fetched via the relationship should match the predicate.
+
+## Options
+
+### A - Specify which equality in metadata
+
+E.g. for a local relationship, we could define which equality we wanted to use for each column in the column mapping:
+
+```yaml
+kind: Relationship
+version: v1
+mapping:
+  - source:
+      fieldPath:
+        - fieldName: artist_id
+  - target:
+      modelField:
+        - fieldName: id
+      operator: _eq
+  - name: artist
+  - source: albums
+  - target:
+      model: 
+        name: artists
+        relationshipType: Object
+```
+
+Note: `operator: _eq` in the example above, defined on `target`, since equality is implemented on the right-hand source in general.
+
+For remote relationships, we would have to require `operator` to be defined on `source` too, at least in cases where the user uses remote relationship predicates.
+
+#### Pros
+
+- Explicit, unambiguous
+
+#### Cons
+
+- No good way for tooling to generate the operator fields, since it won't know which equality to choose
+- Too verbose possibly
+
+### B - Specify which equality in the NDC schema
+
+The NDC schema could contain multiple equality operators per scalar type, but identify syntactic or definitional equality separately in the response, for use in object lookups or relationships:
+
+```json
+{
+ "scalar_types": {
+    "String": {
+      "aggregate_functions": {},
+      "syntactic_equality": "eq",
+      "comparison_operators": {
+        "eq": {
+          "type": "equal"
+        },
+        "like": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "String"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Note: `"syntactic_equality": "eq"` above.
+
+#### Pros
+
+- No change to metadata
+- Unambiguous
+
+#### Cons
+
+- Breaking change to NDC
+- Can't use non-definitional equality in relationship definitions
+
+### C - Combination of options A and B
+
+Specify the equality in metadata, like option A, but also identify the definitional equality in the NDC schema, if it exists, to assist tooling in generating the metadata.
+
+This combines some of the pros and cons of those options. Metadata only needs to change if the user wants to use a custom equality operator for some reason, tooling can work automatically, but there is a breaking change to NDC.
+
+#### Pros
+
+- Explicit, unambiguous
+
+#### Cons
+
+- Breaking change to NDC
+
+### D - Only allow a single equality operator
+
+- It would be an error for the NDC schema response to contain multiple equality operators.
+- We add requirements to the specification to explain that equality operators are required to be definitional/syntactic. We can capture this in a couple of ways:
+  - (Definitional equality) We can require substituting equals-for-equals in requests to give equal responses
+  - (Syntactic equality) We can require that a single where clause with an equality predicate to return the provided value verbatim in the response JSON for the same column. This is probably easier to test.
+
+#### Pros
+
+- No changes needed to existing connectors
+
+#### Cons
+
+- Now we can't use alternative equality operators in relationship definitions.
+  - We could support this later
+- Some types don't have a valid definitional/syntactic equality (e.g. `citext`) so we wouldn't be able to define any PK lookups or relationships against columns with those types.
+- Can't test non-equals operators
+  - We could add a "weak-equals" operator type ("equivalence") to support this.
+
+## Proposal
+
+Currently we are leaning towards option D because it's non-breaking, but we might want to consider other options in the next round of breaking changes.

--- a/specification/src/specification/schema/scalar-types.md
+++ b/specification/src/specification/schema/scalar-types.md
@@ -42,9 +42,14 @@ For example:
 
 An operator defined using type `equal` tests if a column value is equal to a scalar value, another column value, or a variable.
 
-The precise semantics of this equality operator are not specified, but the operator should define an equivalence relation. That is, its argument type should be the same scalar type for which it is defined, and at the level of values, it should be reflexive, symmetric and transitive.
+##### Note: syntactic equality
 
-For example, an equality operator on a string type might test equality at the level of the underlying bytes, or might perform a coarser-grained test such as case-insensitive comparison.
+Specifically, a predicate expression which uses an operator of type `equal` should implement _syntactic equality_:
+
+- An expression which tests for equality of a column with a _scalar_ value or _variable_ should return that scalar value exactly (equal as JSON values) for all rows in each corresponding row set, whenever the same column is selected.
+- An expression which tests for equality of a column with _another column_ should return the same values in both columns (equal as JSON values) for all rows in each corresponding row set, whenever both of those those columns are selected.
+
+This type of equality is quite strict, and it might not be possible to implement such an operator for all scalar types. For example, a case-insensitive string type's natural case-insensitive equality operator would not meet the criteria above. In such cases, the scalar type should _not_ provide an _equal_ operator.
 
 #### `In`
 


### PR DESCRIPTION
[Rendered](https://github.com/hasura/ndc-spec/blob/rfc/equality/rfcs/0006-equality.md)

- Only allow a single syntactic `equal` operator per scalar type
- `ndc-test` changes to require this