### PR TITLE
Fix incorrect OpenAPI name for `TypeRepresentation`

### DIFF
--- a/ndc-client/src/models.rs
+++ b/ndc-client/src/models.rs
@@ -123,7 +123,7 @@ pub struct ScalarType {
     Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, JsonSchema,
 )]
 #[serde(tag = "type", rename_all = "snake_case")]
-#[schemars(title = "Type")]
+#[schemars(title = "Type Representation")]
 pub enum TypeRepresentation {
     /// JSON booleans
     Boolean,

--- a/ndc-client/tests/json_schema/schema_response.jsonschema
+++ b/ndc-client/tests/json_schema/schema_response.jsonschema
@@ -84,7 +84,7 @@
       }
     },
     "TypeRepresentation": {
-      "title": "Type",
+      "title": "Type Representation",
       "description": "Representations of scalar types",
       "oneOf": [
         {


### PR DESCRIPTION
Unfortunately, it seems like `TypeRepresentation` was given the same OpenAPI title as `Type`, which results in a duplicated type name when used in the TypeScript SDK's OpenAPI type generator. This fixes the issue.