### PR TITLE
Improve error output in `ndc-test`

### DIFF
--- a/ndc-test/src/error.rs
+++ b/ndc-test/src/error.rs
@@ -64,7 +64,7 @@ pub enum Error {
     BenchmarkExceededTolerance(f64),
     #[error("response from connector does not satisfy requirement: {0}")]
     ResponseDoesNotSatisfy(String),
-    #[error("other error")]
+    #[error("other error: {0}")]
     OtherError(#[from] Box<dyn std::error::Error>),
 }
 


### PR DESCRIPTION
This PR simply makes the test suite print out the actual error when there is an "other error".