### PR TITLE
add ndc-models to root Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 package.version = "0.1.1"
 
 members = [
+  "ndc-models",
   "ndc-reference",
   "ndc-test",
 ]


### PR DESCRIPTION
`ndc-sdk-typescript` generates jsonschema from `ndc-models`. This package should be exposed in the root Cargo.toml