### PR TITLE
Added a biginteger type representation

### DIFF
--- a/ndc-models/src/lib.rs
+++ b/ndc-models/src/lib.rs
@@ -151,6 +151,9 @@ pub enum TypeRepresentation {
     Float32,
     /// An IEEE-754 double-precision floating-point number
     Float64,
+    /// Arbitrary-precision integer string
+    #[serde(rename = "biginteger")]
+    BigInteger,
     /// Arbitrary-precision decimal string
     #[serde(rename = "bigdecimal")]
     BigDecimal,

--- a/ndc-models/tests/json_schema/schema_response.jsonschema
+++ b/ndc-models/tests/json_schema/schema_response.jsonschema
@@ -240,6 +240,21 @@
           }
         },
         {
+          "description": "Arbitrary-precision integer string",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "biginteger"
+              ]
+            }
+          }
+        },
+        {
           "description": "Arbitrary-precision decimal string",
           "type": "object",
           "required": [

--- a/specification/src/specification/changelog.md
+++ b/specification/src/specification/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Specification
+
+- Added a `biginteger` [type representation](./schema/scalar-types.md#type-representations)
+
+
 ## `0.1.2`
 
 ### Specification

--- a/specification/src/specification/schema/scalar-types.md
+++ b/specification/src/specification/schema/scalar-types.md
@@ -22,6 +22,7 @@ If the representation is omitted, it defaults to `json`.
 | `int64` | A 64-bit signed integer with a minimum value of -2^63 and a maximum value of 2^63 - 1 | String |
 | `float32` | An IEEE-754 single-precision floating-point number | Number |
 | `float64` | An IEEE-754 double-precision floating-point number | Number |
+| `biginteger` | Arbitrary-precision integer string | String |
 | `bigdecimal` | Arbitrary-precision decimal string | String |
 | `uuid` | UUID string (8-4-4-4-12 format) | String |
 | `date` | ISO 8601 date | String |


### PR DESCRIPTION
Adds a `biginteger` type representation, which is like `bigdecimal` but only contains integers. 
This is useful to represent JavaScript's [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#bigint_type) type.