### PR TITLE
Remove duplication by setting values in the workspace file.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,24 @@ too_many_lines = { level = "allow" }
 wildcard_imports = { level = "allow" }
 # disable these for now, but we should probably fix them
 needless_pass_by_value = { level = "allow" }
+
+[workspace.dependencies]
+async-trait = "0.1"
+axum = "0.6"
+clap = "4"
+colorful = "0.2"
+goldenfile = "1"
+indexmap = "2"
+prometheus = "0.13"
+rand = "0.8"
+regex = "1"
+reqwest = { version = "0.11", default-features = false }
+schemars = "0.8"
+semver = "1"
+serde = "1"
+serde_json = "1"
+serde_with = "3"
+thiserror = "1"
+tokio = "1"
+tokio-test = "0.4"
+url = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 
 package.version = "0.1.4"
+package.edition = "2021"
 
 members = [
   "ndc-models",

--- a/ndc-models/Cargo.toml
+++ b/ndc-models/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ndc-models"
 description = "Protocol definitions for the Hasura NDC specification"
-version = "0.1.4"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/ndc-models/Cargo.toml
+++ b/ndc-models/Cargo.toml
@@ -8,11 +8,11 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-indexmap = { version = "2", features = ["serde"] }
-schemars = { version = "0.8", features = ["indexmap2", "preserve_order", "smol_str"] }
-serde = "1"
-serde_json = { version = "1", features = ["preserve_order"] }
-serde_with = "3"
+indexmap = { workspace = true, features = ["serde"] }
+schemars = { workspace = true, features = ["indexmap2", "preserve_order", "smol_str"] }
+serde = { workspace = true }
+serde_json = { workspace = true, features = ["preserve_order"] }
+serde_with = { workspace = true }
 
 [dev-dependencies]
-goldenfile = "1"
+goldenfile = { workspace = true }

--- a/ndc-reference/Cargo.toml
+++ b/ndc-reference/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ndc-reference"
-version = "0.1.4"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/ndc-reference/Cargo.toml
+++ b/ndc-reference/Cargo.toml
@@ -13,16 +13,16 @@ path = "bin/reference/main.rs"
 [dependencies]
 ndc-models = { path = "../ndc-models" }
 
-axum = "0.6"
-indexmap = { version = "2", features = ["serde"] }
-prometheus = "0.13"
-regex = "1"
-serde_json = "1"
-tokio = { version = "1", features = ["macros", "parking_lot", "rt-multi-thread", "signal"] }
+axum = { workspace = true }
+indexmap = { workspace = true, features = ["serde"] }
+prometheus = { workspace = true }
+regex = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "parking_lot", "rt-multi-thread", "signal"] }
 
 [dev-dependencies]
 ndc-test = { path = "../ndc-test" }
 
-async-trait = "0.1"
-goldenfile = "1"
-tokio-test = "0.4"
+async-trait = { workspace = true }
+goldenfile = { workspace = true }
+tokio-test = { workspace = true }

--- a/ndc-test/Cargo.toml
+++ b/ndc-test/Cargo.toml
@@ -16,15 +16,15 @@ rustls = ["reqwest/rustls"]
 [dependencies]
 ndc-models = { path = "../ndc-models" }
 
-async-trait = "0.1"
-clap = { version = "4", features = ["derive"] }
-colorful = "0.2"
-indexmap = { version = "2", features = ["serde"] }
-rand = { version = "0.8", features = ["small_rng"] }
-reqwest = { version = "0.11", features = ["json", "multipart"], default-features = false }
-semver = "1"
-serde = "1"
-serde_json = { version = "1", features = ["preserve_order"] }
-thiserror = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "parking_lot"] }
-url = "2"
+async-trait = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+colorful = { workspace = true }
+indexmap = { workspace = true, features = ["serde"] }
+rand = { workspace = true, features = ["small_rng"] }
+reqwest = { workspace = true, features = ["json", "multipart"] }
+semver = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true, features = ["preserve_order"] }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "parking_lot"] }
+url = { workspace = true }

--- a/ndc-test/Cargo.toml
+++ b/ndc-test/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ndc-test"
 description = "A tool to verify that a data connector is somewhat compatible with the specification"
-version = "0.1.4"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
We set the package version and edition in the workspace file.

We also use the workspace file to capture dependency versions, so that they are kept consistent across crates. The crates themselves still specify the features.