### PR TITLE
Borrowing for newtype wrappers

### DIFF
--- a/ndc-models/src/lib.rs
+++ b/ndc-models/src/lib.rs
@@ -933,6 +933,42 @@ newtype! {ScalarTypeName over TypeName}
 newtype! {TypeName}
 newtype! {VariableName}
 
+impl From<String> for FunctionName {
+    fn from(value: String) -> Self {
+        FunctionName(value.into())
+    }
+}
+
+impl From<FunctionName> for String {
+    fn from(value: FunctionName) -> Self {
+        value.0.into()
+    }
+}
+
+impl From<String> for ObjectTypeName {
+    fn from(value: String) -> Self {
+        ObjectTypeName(value.into())
+    }
+}
+
+impl From<ObjectTypeName> for String {
+    fn from(value: ObjectTypeName) -> Self {
+        value.0.into()
+    }
+}
+
+impl From<String> for ScalarTypeName {
+    fn from(value: String) -> Self {
+        ScalarTypeName(value.into())
+    }
+}
+
+impl From<ScalarTypeName> for String {
+    fn from(value: ScalarTypeName) -> Self {
+        value.0.into()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Write;

--- a/ndc-models/src/lib.rs
+++ b/ndc-models/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(deprecated)]
 
-use std::collections::BTreeMap;
+use std::{borrow::Borrow, collections::BTreeMap};
 
 use indexmap::IndexMap;
 use schemars::JsonSchema;
@@ -870,6 +870,18 @@ macro_rules! newtype {
         impl std::fmt::Display for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 self.0.fmt(f)
+            }
+        }
+
+        impl Borrow<str> for $name {
+            fn borrow(&self) -> &str {
+                self.0.as_str()
+            }
+        }
+
+        impl Borrow<$oldtype> for $name {
+            fn borrow(&self) -> &$oldtype {
+                &self.0
             }
         }
 

--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -45,7 +45,7 @@ fn read_json_lines(contents: &str) -> core::result::Result<BTreeMap<i32, Row>, B
     for line in contents.lines() {
         let row: BTreeMap<models::FieldName, serde_json::Value> = serde_json::from_str(line)?;
         let id: i32 = row
-            .get(&models::FieldName::new("id".into()))
+            .get("id")
             .ok_or("'id' field not found in json file")?
             .as_i64()
             .ok_or("'id' field was not an integer in json file")?
@@ -754,15 +754,13 @@ fn get_collection_by_name(
         "authors" => Ok(state.authors.values().cloned().collect()),
         "institutions" => Ok(state.institutions.values().cloned().collect()),
         "articles_by_author" => {
-            let author_id = arguments
-                .get(&models::ArgumentName::from("author_id"))
-                .ok_or((
-                    StatusCode::BAD_REQUEST,
-                    Json(models::ErrorResponse {
-                        message: "missing argument author_id".into(),
-                        details: serde_json::Value::Null,
-                    }),
-                ))?;
+            let author_id = arguments.get("author_id").ok_or((
+                StatusCode::BAD_REQUEST,
+                Json(models::ErrorResponse {
+                    message: "missing argument author_id".into(),
+                    details: serde_json::Value::Null,
+                }),
+            ))?;
             let author_id_int: i32 = author_id
                 .as_i64()
                 .ok_or((
@@ -786,15 +784,13 @@ fn get_collection_by_name(
             let mut articles_by_author = vec![];
 
             for article in state.articles.values() {
-                let article_author_id = article
-                    .get(&models::FieldName::new("author_id".into()))
-                    .ok_or((
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(models::ErrorResponse {
-                            message: "author_id not found".into(),
-                            details: serde_json::Value::Null,
-                        }),
-                    ))?;
+                let article_author_id = article.get("author_id").ok_or((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(models::ErrorResponse {
+                        message: "author_id not found".into(),
+                        details: serde_json::Value::Null,
+                    }),
+                ))?;
                 let article_author_id_int: i32 = article_author_id
                     .as_i64()
                     .ok_or((
@@ -1819,7 +1815,7 @@ fn eval_column(
     ))?;
 
     if let Some(array) = column.as_array() {
-        let limit_argument = arguments.get(&models::ArgumentName::from("limit")).ok_or((
+        let limit_argument = arguments.get("limit").ok_or((
             StatusCode::BAD_REQUEST,
             Json(models::ErrorResponse {
                 message: format!("Expected argument 'limit' in column {column_name}"),
@@ -2137,15 +2133,13 @@ fn execute_upsert_article(
     collection_relationships: &BTreeMap<models::RelationshipName, models::Relationship>,
 ) -> std::result::Result<models::MutationOperationResults, (StatusCode, Json<models::ErrorResponse>)>
 {
-    let article = arguments
-        .get(&models::ArgumentName::from("article"))
-        .ok_or((
-            StatusCode::BAD_REQUEST,
-            Json(models::ErrorResponse {
-                message: "Expected argument 'article'".into(),
-                details: serde_json::Value::Null,
-            }),
-        ))?;
+    let article = arguments.get("article").ok_or((
+        StatusCode::BAD_REQUEST,
+        Json(models::ErrorResponse {
+            message: "Expected argument 'article'".into(),
+            details: serde_json::Value::Null,
+        }),
+    ))?;
     let article_obj: Row = serde_json::from_value(article.clone()).map_err(|_| {
         (
             StatusCode::BAD_REQUEST,
@@ -2155,15 +2149,13 @@ fn execute_upsert_article(
             }),
         )
     })?;
-    let id = article_obj
-        .get(&models::FieldName::new("id".into()))
-        .ok_or((
-            StatusCode::BAD_REQUEST,
-            Json(models::ErrorResponse {
-                message: "article missing field 'id'".into(),
-                details: serde_json::Value::Null,
-            }),
-        ))?;
+    let id = article_obj.get("id").ok_or((
+        StatusCode::BAD_REQUEST,
+        Json(models::ErrorResponse {
+            message: "article missing field 'id'".into(),
+            details: serde_json::Value::Null,
+        }),
+    ))?;
     let id_int = id
         .as_i64()
         .ok_or((
@@ -2221,7 +2213,7 @@ fn execute_delete_articles(
     collection_relationships: &BTreeMap<models::RelationshipName, models::Relationship>,
 ) -> std::result::Result<models::MutationOperationResults, (StatusCode, Json<models::ErrorResponse>)>
 {
-    let predicate_value = arguments.get(&models::ArgumentName::from("where")).ok_or((
+    let predicate_value = arguments.get("where").ok_or((
         StatusCode::BAD_REQUEST,
         Json(models::ErrorResponse {
             message: "Expected argument 'where'".into(),

--- a/ndc-test/src/test_cases/query/aggregates/mod.rs
+++ b/ndc-test/src/test_cases/query/aggregates/mod.rs
@@ -84,10 +84,7 @@ pub async fn test_star_count_aggregate<C: Connector>(
     let row_set = expect_single_rowset(response)?;
 
     if let Some(aggregates) = &row_set.aggregates {
-        match aggregates
-            .get(&models::FieldName::from("count"))
-            .and_then(serde_json::Value::as_u64)
-        {
+        match aggregates.get("count").and_then(serde_json::Value::as_u64) {
             None => Err(Error::MissingField("count".into())),
             Some(count) => Ok(count),
         }
@@ -196,10 +193,7 @@ pub async fn test_single_column_aggregates<C: Connector>(
 
     for (field_name, field) in &collection_type.fields {
         if let Some(name) = super::common::as_named_type(&field.r#type) {
-            if let Some(scalar_type) = schema
-                .scalar_types
-                .get(&models::ScalarTypeName::new(name.clone()))
-            {
+            if let Some(scalar_type) = schema.scalar_types.get(name) {
                 for function_name in scalar_type.aggregate_functions.keys() {
                     let aggregate = models::Aggregate::SingleColumn {
                         column: field_name.clone(),

--- a/ndc-test/src/test_cases/query/simple_queries/predicates.rs
+++ b/ndc-test/src/test_cases/query/simple_queries/predicates.rs
@@ -122,10 +122,7 @@ fn make_single_expressions(
     }
 
     if let Some(field_type_name) = super::super::common::get_named_type(field_type) {
-        if let Some(field_scalar_type) = schema
-            .scalar_types
-            .get(&models::ScalarTypeName::new(field_type_name.clone()))
-        {
+        if let Some(field_scalar_type) = schema.scalar_types.get(field_type_name) {
             for (operator_name, operator) in &field_scalar_type.comparison_operators {
                 match operator {
                     models::ComparisonOperatorDefinition::Equal => {

--- a/ndc-test/src/test_cases/query/validate/mod.rs
+++ b/ndc-test/src/test_cases/query/validate/mod.rs
@@ -304,10 +304,7 @@ pub fn check_value_has_type(
             }
         }
         models::Type::Named { name } => {
-            if let Some(object_type) = schema
-                .object_types
-                .get(&ndc_models::ObjectTypeName::new(name.clone()))
-            {
+            if let Some(object_type) = schema.object_types.get(name) {
                 if let Some(object_fields) = value.as_object() {
                     let object = object_fields
                         .iter()
@@ -329,10 +326,7 @@ pub fn check_value_has_type(
                 } else {
                     Err(Error::InvalidValueInResponse(json_path, "object".into()))
                 }
-            } else if let Some(scalar_type) = schema
-                .scalar_types
-                .get(&ndc_models::ScalarTypeName::new(name.clone()))
-            {
+            } else if let Some(scalar_type) = schema.scalar_types.get(name) {
                 if let Some(representation) = &scalar_type.representation {
                     representations::check_value_has_representation(
                         representation,


### PR DESCRIPTION
This is just a quick fix to add [Borrow trait](https://doc.rust-lang.org/std/borrow/trait.Borrow.html) implementations for the new newtype wrappers so that the following works:

```rust
let arguments: &BTreeMap<ndc_models::ArgumentName, serde_json::Value> = todo!();
arguments.get("name") // can now pass a &str into a map and it works
```

Otherwise you have to write a special allocation:

```rust
arguments.get(&ndc_models::ArgumentName::from("movie_id"))
```

Also, the PR adds From instances to and from String for the double-wrapped newtypes, such as `FunctionName`.