### PR TITLE
Add RefCast trait to newtypes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,7 @@ version = "0.1.4"
 dependencies = [
  "goldenfile",
  "indexmap 2.2.6",
+ "ref-cast",
  "schemars",
  "serde",
  "serde_json",
@@ -1128,6 +1129,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
  "bitflags 2.5.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ goldenfile = "1"
 indexmap = "2"
 prometheus = "0.13"
 rand = "0.8"
+ref-cast = "1.0"
 regex = "1"
 reqwest = { version = "0.11", default-features = false }
 schemars = "0.8"

--- a/ndc-models/Cargo.toml
+++ b/ndc-models/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 indexmap = { workspace = true, features = ["serde"] }
+ref-cast = { workspace = true }
 schemars = { workspace = true, features = ["indexmap2", "preserve_order", "smol_str"] }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }

--- a/ndc-models/src/lib.rs
+++ b/ndc-models/src/lib.rs
@@ -3,6 +3,7 @@
 use std::{borrow::Borrow, collections::BTreeMap};
 
 use indexmap::IndexMap;
+use ref_cast::RefCast;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -821,8 +822,19 @@ pub enum MutationOperationResults {
 macro_rules! newtype {
     ($name: ident over $oldtype: ident) => {
         #[derive(
-            Clone, Debug, Default, Hash, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize,
+            Clone,
+            Debug,
+            Default,
+            Hash,
+            Eq,
+            Ord,
+            PartialEq,
+            PartialOrd,
+            Serialize,
+            Deserialize,
+            RefCast,
         )]
+        #[repr(transparent)]
         pub struct $name($oldtype);
 
         impl JsonSchema for $name {


### PR DESCRIPTION
As suggested by @SamirTalwar in #159, this PR adds the [RefCast](https://docs.rs/ref-cast/latest/ref_cast/) trait to all newtype wrappers which allows the safe casting of `&SmolStr` to `&MySmolStrWrappingNewtype`.