### PR TITLE
Health endpoint is required not merely recommended

### DIFF
--- a/specification/src/specification/health.md
+++ b/specification/src/specification/health.md
@@ -1,6 +1,6 @@
 # Service Health
 
-Data connectors should provide a __health endpoint__ which can be used to indicate service health and readiness to any client applications.
+Data connectors must provide a __health endpoint__ which can be used to indicate service health and readiness to any client applications.
 
 ## Request
 


### PR DESCRIPTION
Minor change to indicate that the /health endpoint is required, not merely recommended (must not should) per [rfc 2119](https://datatracker.ietf.org/doc/html/rfc2119)

DX and control plane tooling relies on this endpoint to function.