### PR TITLE
add an explicit requirement of ordering of variables

### DIFF
--- a/specification/src/specification/queries/variables.md
+++ b/specification/src/specification/queries/variables.md
@@ -19,6 +19,5 @@ The result contains one rowset containing articles from the author with ID `1`, 
 
 ## Requirements
 
-- If `variables` are provided in the [`QueryRequest`](../../reference/types.md#queryrequest), then the [`QueryResponse`](../../reference/types.md#queryresponse) should contain one [`RowSet`](../../reference/types.md#rowset) for each set of variables.
-  - The ordering of `RowSet`s should EXACTLY match the ordering of the `variables` provided.
+- If `variables` are provided in the [`QueryRequest`](../../reference/types.md#queryrequest), then the [`QueryResponse`](../../reference/types.md#queryresponse) should contain one [`RowSet`](../../reference/types.md#rowset) for each set of variables, in the same order.
 - If `variables` are not provided, the data connector should return a single [`RowSet`](../../reference/types.md#rowset).

--- a/specification/src/specification/queries/variables.md
+++ b/specification/src/specification/queries/variables.md
@@ -20,5 +20,5 @@ The result contains one rowset containing articles from the author with ID `1`, 
 ## Requirements
 
 - If `variables` are provided in the [`QueryRequest`](../../reference/types.md#queryrequest), then the [`QueryResponse`](../../reference/types.md#queryresponse) should contain one [`RowSet`](../../reference/types.md#rowset) for each set of variables.
-    - The ordering of [`RowSet`]s should EXACTLY match the ordering of the `variables` provided.
+  - The ordering of `RowSet`s should EXACTLY match the ordering of the `variables` provided.
 - If `variables` are not provided, the data connector should return a single [`RowSet`](../../reference/types.md#rowset).

--- a/specification/src/specification/queries/variables.md
+++ b/specification/src/specification/queries/variables.md
@@ -20,4 +20,5 @@ The result contains one rowset containing articles from the author with ID `1`, 
 ## Requirements
 
 - If `variables` are provided in the [`QueryRequest`](../../reference/types.md#queryrequest), then the [`QueryResponse`](../../reference/types.md#queryresponse) should contain one [`RowSet`](../../reference/types.md#rowset) for each set of variables.
+    - The ordering of [`RowSet`]s should EXACTLY match the ordering of the `variables` provided.
 - If `variables` are not provided, the data connector should return a single [`RowSet`](../../reference/types.md#rowset).


### PR DESCRIPTION
<!---
If you are contributing to this repository, the first step is to discuss any planned changes in an RFC.
-->

In case of variables, explicitly add a requirement that the ordering of the `RowSet`s in the response should match the order of the variables in the query request. 

This is important because, if the connector author doesn't follow this, it could result in undefined results.

- [ ] RFC
- [x] Specification updates
  - [ ] Changelog
  - [x] Specification pages
  - [ ] Tutorial pages
  - [ ] `reference/types.md`
- [ ] Implement your feature in the reference connector
- [ ] Generate test cases in `ndc-test` if appropriate
- [ ] Does your feature add a new capability?
  - [ ] Update `specification/capabilities.md` in the specification
  - [ ] Check the capability in `ndc-test`
