### PR TITLE
Remove path from GroupOrderByTarget::Aggregate

### DIFF
--- a/ndc-models/src/lib.rs
+++ b/ndc-models/src/lib.rs
@@ -636,8 +636,6 @@ pub enum GroupOrderByTarget {
     Aggregate {
         /// Aggregation method to apply
         aggregate: Aggregate,
-        /// Non-empty collection of relationships to traverse
-        path: Vec<PathElement>,
     },
 }
 // ANCHOR_END: GroupOrderByTarget

--- a/ndc-models/tests/json_schema/mutation_request.jsonschema
+++ b/ndc-models/tests/json_schema/mutation_request.jsonschema
@@ -1337,7 +1337,6 @@
           "type": "object",
           "required": [
             "aggregate",
-            "path",
             "type"
           ],
           "properties": {
@@ -1354,13 +1353,6 @@
                   "$ref": "#/definitions/Aggregate"
                 }
               ]
-            },
-            "path": {
-              "description": "Non-empty collection of relationships to traverse",
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/PathElement"
-              }
             }
           }
         }

--- a/ndc-models/tests/json_schema/query_request.jsonschema
+++ b/ndc-models/tests/json_schema/query_request.jsonschema
@@ -1322,7 +1322,6 @@
           "type": "object",
           "required": [
             "aggregate",
-            "path",
             "type"
           ],
           "properties": {
@@ -1339,13 +1338,6 @@
                   "$ref": "#/definitions/Aggregate"
                 }
               ]
-            },
-            "path": {
-              "description": "Non-empty collection of relationships to traverse",
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/PathElement"
-              }
             }
           }
         }


### PR DESCRIPTION
This PR removes the `path` field from `GroupOrderByTarget::Aggregate`.

`path` should not exist on `GroupOrderByTarget::Aggregate`. I think `path` was copied from `OrderByTarget::Aggregate` (ie from normal row ordering) by mistake. Group aggregate ordering is not the same as row aggregate ordering. When we do group ordering, we are aggregating the _group_ of rows and then ordering the groups by the aggregate result. When we do aggregations in normal row ordering, we are computing an aggregate _per row_ and then ordering the rows by the aggregate result.

This is why `path` exists in row ordering. We can traverse a relationship from the row (probably an array relationship) in order to get an array of related rows to aggregate. (eg order Invoices by the count of each Invoice's InvoiceLines)
However, that is _not_ valid for group ordering. We are aggregating the rows in the group, it makes no sense to traverse anything before doing that.

I'd also add that when we compute aggregates for groups to return (rather than to order with), we cannot specify a `path`, we can only specify an `Aggregate`. This is another demonstration of why `path` should not exist for group aggregate ordering.

```rust
pub struct Grouping {
    /// Dimensions along which to partition the data
    pub dimensions: Vec<Dimension>,
    /// Aggregates to compute in each group
    pub aggregates: IndexMap<String, Aggregate>,
    ...
}
```