### PR TITLE
Add additional support for field arguments to comparisons, ordering, aggregates and group dimensions

### DIFF
--- a/ndc-models/src/lib.rs
+++ b/ndc-models/src/lib.rs
@@ -596,6 +596,9 @@ pub enum Dimension {
     Column {
         /// The name of the column
         column_name: FieldName,
+        /// Arguments to satisfy the column specified by 'column_name'
+        #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+        arguments: BTreeMap<ArgumentName, Argument>,
         /// Path to a nested field within an object column
         field_path: Option<Vec<FieldName>>,
         /// Any (object) relationships to traverse to reach this column
@@ -649,6 +652,9 @@ pub enum Aggregate {
     ColumnCount {
         /// The column to apply the count aggregate function to
         column: FieldName,
+        /// Arguments to satisfy the column specified by 'column'
+        #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+        arguments: BTreeMap<ArgumentName, Argument>,
         /// Path to a nested field within an object column
         field_path: Option<Vec<FieldName>>,
         /// Whether or not only distinct items should be counted
@@ -657,6 +663,9 @@ pub enum Aggregate {
     SingleColumn {
         /// The column to apply the aggregation function to
         column: FieldName,
+        /// Arguments to satisfy the column specified by 'column'
+        #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+        arguments: BTreeMap<ArgumentName, Argument>,
         /// Path to a nested field within an object column
         field_path: Option<Vec<FieldName>>,
         /// Single column aggregate function name.
@@ -756,6 +765,9 @@ pub enum OrderByTarget {
     Column {
         /// The name of the column
         name: FieldName,
+        /// Arguments to satisfy the column specified by 'name'
+        #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+        arguments: BTreeMap<ArgumentName, Argument>,
         /// Path to a nested field within an object column
         field_path: Option<Vec<FieldName>>,
         /// Any (object) relationships to traverse to reach this column
@@ -832,6 +844,9 @@ pub enum ComparisonTarget {
     Column {
         /// The name of the column
         name: FieldName,
+        /// Arguments to satisfy the column specified by 'name'
+        #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+        arguments: BTreeMap<ArgumentName, Argument>,
         /// Path to a nested field within an object column
         field_path: Option<Vec<FieldName>>,
     },
@@ -866,6 +881,9 @@ pub enum ComparisonValue {
     Column {
         /// The name of the column
         name: FieldName,
+        /// Arguments to satisfy the column specified by 'name'
+        #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+        arguments: BTreeMap<ArgumentName, Argument>,
         /// Path to a nested field within an object column
         field_path: Option<Vec<FieldName>>,
         /// Any relationships to traverse to reach this column

--- a/ndc-models/tests/json_schema/mutation_request.jsonschema
+++ b/ndc-models/tests/json_schema/mutation_request.jsonschema
@@ -339,6 +339,13 @@
               "description": "The column to apply the count aggregate function to",
               "type": "string"
             },
+            "arguments": {
+              "description": "Arguments to satisfy the column specified by 'column'",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
+            },
             "field_path": {
               "description": "Path to a nested field within an object column",
               "type": [
@@ -372,6 +379,13 @@
             "column": {
               "description": "The column to apply the aggregation function to",
               "type": "string"
+            },
+            "arguments": {
+              "description": "Arguments to satisfy the column specified by 'column'",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
             },
             "field_path": {
               "description": "Path to a nested field within an object column",
@@ -465,6 +479,13 @@
             "name": {
               "description": "The name of the column",
               "type": "string"
+            },
+            "arguments": {
+              "description": "Arguments to satisfy the column specified by 'name'",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
             },
             "field_path": {
               "description": "Path to a nested field within an object column",
@@ -770,6 +791,13 @@
               "description": "The name of the column",
               "type": "string"
             },
+            "arguments": {
+              "description": "Arguments to satisfy the column specified by 'name'",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
+            },
             "field_path": {
               "description": "Path to a nested field within an object column",
               "type": [
@@ -841,6 +869,13 @@
             "name": {
               "description": "The name of the column",
               "type": "string"
+            },
+            "arguments": {
+              "description": "Arguments to satisfy the column specified by 'name'",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
             },
             "field_path": {
               "description": "Path to a nested field within an object column",
@@ -1080,6 +1115,13 @@
             "column_name": {
               "description": "The name of the column",
               "type": "string"
+            },
+            "arguments": {
+              "description": "Arguments to satisfy the column specified by 'column_name'",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
             },
             "field_path": {
               "description": "Path to a nested field within an object column",

--- a/ndc-models/tests/json_schema/query_request.jsonschema
+++ b/ndc-models/tests/json_schema/query_request.jsonschema
@@ -147,6 +147,13 @@
               "description": "The column to apply the count aggregate function to",
               "type": "string"
             },
+            "arguments": {
+              "description": "Arguments to satisfy the column specified by 'column'",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
+            },
             "field_path": {
               "description": "Path to a nested field within an object column",
               "type": [
@@ -181,6 +188,13 @@
               "description": "The column to apply the aggregation function to",
               "type": "string"
             },
+            "arguments": {
+              "description": "Arguments to satisfy the column specified by 'column'",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
+            },
             "field_path": {
               "description": "Path to a nested field within an object column",
               "type": [
@@ -209,6 +223,47 @@
                 "star_count"
               ]
             }
+          }
+        }
+      ]
+    },
+    "Argument": {
+      "title": "Argument",
+      "oneOf": [
+        {
+          "description": "The argument is provided by reference to a variable",
+          "type": "object",
+          "required": [
+            "name",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "variable"
+              ]
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "The argument is provided as a literal value",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "literal"
+              ]
+            },
+            "value": true
           }
         }
       ]
@@ -349,47 +404,6 @@
         }
       ]
     },
-    "Argument": {
-      "title": "Argument",
-      "oneOf": [
-        {
-          "description": "The argument is provided by reference to a variable",
-          "type": "object",
-          "required": [
-            "name",
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "variable"
-              ]
-            },
-            "name": {
-              "type": "string"
-            }
-          }
-        },
-        {
-          "description": "The argument is provided as a literal value",
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "literal"
-              ]
-            },
-            "value": true
-          }
-        }
-      ]
-    },
     "RelationshipArgument": {
       "title": "Relationship Argument",
       "oneOf": [
@@ -509,6 +523,13 @@
             "name": {
               "description": "The name of the column",
               "type": "string"
+            },
+            "arguments": {
+              "description": "Arguments to satisfy the column specified by 'name'",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
             },
             "field_path": {
               "description": "Path to a nested field within an object column",
@@ -755,6 +776,13 @@
               "description": "The name of the column",
               "type": "string"
             },
+            "arguments": {
+              "description": "Arguments to satisfy the column specified by 'name'",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
+            },
             "field_path": {
               "description": "Path to a nested field within an object column",
               "type": [
@@ -826,6 +854,13 @@
             "name": {
               "description": "The name of the column",
               "type": "string"
+            },
+            "arguments": {
+              "description": "Arguments to satisfy the column specified by 'name'",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
             },
             "field_path": {
               "description": "Path to a nested field within an object column",
@@ -1065,6 +1100,13 @@
             "column_name": {
               "description": "The name of the column",
               "type": "string"
+            },
+            "arguments": {
+              "description": "Arguments to satisfy the column specified by 'column_name'",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
             },
             "field_path": {
               "description": "Path to a nested field within an object column",

--- a/ndc-test/src/test_cases/query/aggregates/mod.rs
+++ b/ndc-test/src/test_cases/query/aggregates/mod.rs
@@ -111,6 +111,7 @@ pub async fn test_column_count_aggregate<C: Connector>(
     for field_name in &field_names {
         let aggregate = models::Aggregate::ColumnCount {
             column: field_name.clone(),
+            arguments: BTreeMap::new(),
             field_path: None,
             distinct: false,
         };
@@ -121,6 +122,7 @@ pub async fn test_column_count_aggregate<C: Connector>(
 
         let aggregate = models::Aggregate::ColumnCount {
             column: field_name.clone(),
+            arguments: BTreeMap::new(),
             field_path: None,
             distinct: true,
         };
@@ -193,12 +195,15 @@ pub async fn test_single_column_aggregates<C: Connector>(
     let mut available_aggregates: IndexMap<models::FieldName, ndc_models::Aggregate> =
         IndexMap::new();
 
-    for (field_name, field) in &collection_type.fields {
+    let fields = common::select_all_columns_without_arguments(collection_type).collect::<Vec<_>>();
+
+    for (field_name, field) in fields {
         if let Some(name) = super::common::as_named_type(&field.r#type) {
             if let Some(scalar_type) = schema.scalar_types.get(name) {
                 for function_name in scalar_type.aggregate_functions.keys() {
                     let aggregate = models::Aggregate::SingleColumn {
                         column: field_name.clone(),
+                        arguments: BTreeMap::new(),
                         field_path: None,
                         function: function_name.clone(),
                     };

--- a/ndc-test/src/test_cases/query/grouping/mod.rs
+++ b/ndc-test/src/test_cases/query/grouping/mod.rs
@@ -48,6 +48,7 @@ pub async fn test_grouping<C: Connector, R: Reporter>(
                             )]),
                             dimensions: vec![models::Dimension::Column {
                                 column_name: dimension_column_name.clone(),
+                                arguments: BTreeMap::new(),
                                 field_path: None,
                                 path: vec![],
                             }],

--- a/ndc-test/src/test_cases/query/simple_queries/predicates.rs
+++ b/ndc-test/src/test_cases/query/simple_queries/predicates.rs
@@ -98,12 +98,17 @@ fn make_single_expressions(
     values: &[serde_json::Value],
     rng: &mut SmallRng,
 ) -> Result<Vec<GeneratedExpression>> {
-    let field_type = &context
+    let object_field = context
         .collection_type
         .fields
         .get(field_name)
-        .ok_or(Error::UnexpectedField(field_name.clone()))?
-        .r#type;
+        .ok_or(Error::UnexpectedField(field_name.clone()))?;
+    let field_type = &object_field.r#type;
+
+    // The tests don't support fields with arguments at this time
+    if !object_field.arguments.is_empty() {
+        return Ok(vec![]);
+    }
 
     let mut expressions: Vec<GeneratedExpression> = vec![];
 
@@ -112,6 +117,7 @@ fn make_single_expressions(
             expr: models::Expression::UnaryComparisonOperator {
                 column: models::ComparisonTarget::Column {
                     name: field_name.clone(),
+                    arguments: BTreeMap::new(),
                     field_path: None,
                 },
                 operator: models::UnaryComparisonOperator::IsNull,
@@ -131,6 +137,7 @@ fn make_single_expressions(
                             expr: models::Expression::BinaryComparisonOperator {
                                 column: models::ComparisonTarget::Column {
                                     name: field_name.clone(),
+                                    arguments: BTreeMap::new(),
                                     field_path: None,
                                 },
                                 operator: operator_name.clone(),
@@ -153,6 +160,7 @@ fn make_single_expressions(
                             expr: models::Expression::BinaryComparisonOperator {
                                 column: models::ComparisonTarget::Column {
                                     name: field_name.clone(),
+                                    arguments: BTreeMap::new(),
                                     field_path: None,
                                 },
                                 operator: operator_name.clone(),

--- a/ndc-test/src/test_cases/query/simple_queries/sorting.rs
+++ b/ndc-test/src/test_cases/query/simple_queries/sorting.rs
@@ -48,6 +48,8 @@ fn make_order_by_elements(
             if schema
                 .scalar_types
                 .contains_key(&ndc_models::ScalarTypeName::new(name.clone()))
+                // The tests don't support fields with arguments at this time
+                && field.arguments.is_empty()
             {
                 sortable_fields.push(field_name);
             }
@@ -72,6 +74,7 @@ fn make_order_by_elements(
                 order_direction,
                 target: models::OrderByTarget::Column {
                     name: field_name.clone(),
+                    arguments: BTreeMap::new(),
                     field_path: None,
                     path: vec![],
                 },

--- a/rfcs/0025-additional-field-argument-support.md
+++ b/rfcs/0025-additional-field-argument-support.md
@@ -1,0 +1,24 @@
+# Additional Field Argument Support
+
+## Problem
+
+Object type fields can declare arguments that must be submitted when the field is evaluated. However, support for using these fields is not universal; there are some features which do not allow the use of fields with arguments, for example in nested field paths, or in relationship column mappings. Those particular examples are harder to address, but there are a few low hanging places where we could easily add support for field arguments in a non-breaking way.
+
+These places are:
+
+- `ComparisonTarget::Column` - one cannot compare _against_ column (ie LHS) that takes arguments
+- `ComparisonValue::Column` - one cannot compare _to_ a column (ie. RHS) that takes arguments
+- `OrderByTarget::Column` - one cannot order by columns that take arguments
+- `Aggregate::ColumnCount` - one cannot count by a column that takes arguments
+- `Aggregate::SingleColumn` - one cannot aggregate a single column that takes arguments
+
+## Solution
+
+Simply adding:
+
+```rust
+#[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+arguments: BTreeMap<ArgumentName, Argument>,
+```
+
+to all these enum variants resolves the problem in a non-breaking manner.

--- a/specification/src/specification/changelog.md
+++ b/specification/src/specification/changelog.md
@@ -26,6 +26,18 @@ Root column references were generalized to _named scopes_. Scopes are introduced
 
 `ComparisonTarget` was extended to allow [filtering by aggregates](./queries/filtering.md#computing-an-aggregate).
 
+### Wider field arguments support
+
+Object type fields can declare arguments that must be submitted when the field is evaluated. However, support for using these fields is not universal; there are some features which do not allow the use of fields with arguments, for example in nested field paths, or in relationship column mappings.
+
+Now, support for field arguments has been added to:
+
+- `ComparisonTarget::Column`
+- `ComparisonValue::Column`
+- `OrderByTarget::Column`
+- `Aggregate::ColumnCount`
+- `Aggregate::SingleColumn`
+
 ### `X-Hasura-NDC-Version` header
 
 Clients can now [indicate the intended protocol version](./versioning.md#requirements) in a HTTP header alongside any request.

--- a/specification/src/specification/changelog.md
+++ b/specification/src/specification/changelog.md
@@ -38,6 +38,8 @@ Now, support for field arguments has been added to:
 - `Aggregate::ColumnCount`
 - `Aggregate::SingleColumn`
 
+However, field arguments are still considered an unstable feature and their use is not recommended outside of very specialized, advanced use cases.
+
 ### `X-Hasura-NDC-Version` header
 
 Clients can now [indicate the intended protocol version](./versioning.md#requirements) in a HTTP header alongside any request.

--- a/specification/src/specification/queries/aggregates.md
+++ b/specification/src/specification/queries/aggregates.md
@@ -12,6 +12,8 @@ There are three types of aggregate:
 
 If the connector supports capability `query.nested_fields.aggregates` then `single_column` and `column_count` aggregates may also [reference nested fields within a column](./filtering.md#referencing-nested-fields-within-columns) using the `field_path` property.
 
+If the column referenced in `single_column` and `column_count` aggregates has [arguments](./arguments.html#field-arguments) defined for it in the schema, then the `arguments` property is used to provide values for those arguments.
+
 ## Example
 
 The following query object requests the aggregated sum of all order totals, along with the count of all orders, and the count of all orders which have associated invoices (via the nullable `invoice_id` column):

--- a/specification/src/specification/queries/arguments.md
+++ b/specification/src/specification/queries/arguments.md
@@ -57,5 +57,9 @@ For example, when ordering by an aggregate of rows in a related collection, and 
 
 ## Field Arguments
 
+> **CAUTION**
+>
+> Field arguments considered somewhat unstable. Fields arguments are not well supported across all aspects of the specification. It is not recommended that field arguments are used, except for very specialized, advanced use cases.
+
 Field arguments can be provided to any field requested (in addition to those described for top-level collections).
 These are specified in the [schema response](../schema/object-types.md) and their use is described in [field selection](./field-selection.md). Their specification and usage matches that of collection arguments above.

--- a/specification/src/specification/queries/filtering.md
+++ b/specification/src/specification/queries/filtering.md
@@ -71,7 +71,7 @@ Comparison operators compare values. The value on the left hand side of any oper
 
 #### Referencing a column from the same collection
 
-If the `ComparisonTarget` has type `column`, then the `name` property refers to a column in the current collection.
+If the `ComparisonTarget` has type `column`, then the `name` property refers to a column in the current collection. The `arguments` property allows clients to submit argument values for columns that require [arguments](./arguments.html#field-arguments).
 
 #### Referencing nested fields within columns
 
@@ -79,7 +79,7 @@ If the `field_path` property is empty or not present then the target is the valu
 
 If `field_path` is non-empty then it refers to a path to a nested field within the named column
 
-_Note_: a `ComparisonTarget` may only have a non-empty `field_path` if the connector supports capability `query.nested_fields.filter_by`).
+_Note_: a `ComparisonTarget` may only have a non-empty `field_path` if the connector supports capability `query.nested_fields.filter_by`.
 
 #### Computing an aggregate
 

--- a/specification/src/specification/queries/grouping.md
+++ b/specification/src/specification/queries/grouping.md
@@ -4,7 +4,9 @@ If a connector supports [aggregates](./aggregates.md), it may also support _grou
 
 Grouping is requested in the query API alongside fields and aggregates, in the `groups` field of the [`Query`](../../reference/types.md#query) object.
 
-A grouping operation specifies one or more _dimensions_ along which to partition the row set. For each group, every row should have equal values in each of those dimension columns.
+A grouping operation specifies one or more _dimensions_ along which to partition the row set. Each dimension selects a column from which to draw values (see [`Dimension::Column`](../../reference/types.md#dimension)). For each group, every row should have equal values in each of those dimension columns.
+
+If the dimension's column's schema defines [arguments](./arguments.html#field-arguments), then the `arguments` property is used to provide values for those arguments.
 
 In addition, a grouping operation specifies _aggregates_ which should be computed and returned for each group separately.
 

--- a/specification/src/specification/queries/sorting.md
+++ b/specification/src/specification/queries/sorting.md
@@ -16,7 +16,7 @@ To compute the ordering from the `order_by` field, data connectors should implem
 ### Type `column`
 
 The property `element.target.name` refers to a column name.
-If the connector supports capability `query.nested_fields.order_by` then the target may also [reference nested fields within a column](./filtering.md#referencing-nested-fields-within-columns) using the `field_path` property.
+If the connector supports capability `query.nested_fields.order_by` then the target may also [reference nested fields within a column](./filtering.md#referencing-nested-fields-within-columns) using the `field_path` property. If the column has [arguments](./arguments.html#field-arguments), the the `arguments` property is used to provide values for the arguments.
 
 If `element.order_direction` is `asc`, then the row with the smaller column comes first.
 


### PR DESCRIPTION
~~**Note:** This PR is currently stacked on #185 and will be rebased once that PR has merged.~~ Rebased on main.

[Rendered](https://github.com/hasura/ndc-spec/blob/daniel/add-arguments-to-places/rfcs/0025-additional-field-argument-support.md)

- [x] RFC
- [x] Specification updates
  - [x] Changelog
  - [x] Specification pages
  - [ ] Tutorial pages
  - [x] `reference/types.md`
- [x] Implement your feature in the reference connector
- [x] Generate test cases in `ndc-test` if appropriate
- [ ] Does your feature add a new capability?
  - [ ] Update `specification/capabilities.md` in the specification
  - [ ] Check the capability in `ndc-test`
