### PR TITLE
Require scalar type representations and remove deprecated ones

### DIFF
--- a/ndc-models/src/lib.rs
+++ b/ndc-models/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 use std::{borrow::Borrow, collections::BTreeMap};
 
 use indexmap::IndexMap;
@@ -211,8 +209,7 @@ pub struct SchemaResponse {
 #[schemars(title = "Scalar Type")]
 pub struct ScalarType {
     /// A description of valid values for this scalar type.
-    /// Defaults to `TypeRepresentation::JSON` if omitted
-    pub representation: Option<TypeRepresentation>,
+    pub representation: TypeRepresentation,
     /// A map from aggregate function names to their definitions. Result type names must be defined scalar types declared in ScalarTypesCapabilities.
     pub aggregate_functions: BTreeMap<AggregateFunctionName, AggregateFunctionDefinition>,
     /// A map from comparison operator names to their definitions. Argument type names must be defined scalar types declared in ScalarTypesCapabilities.
@@ -232,12 +229,6 @@ pub enum TypeRepresentation {
     Boolean,
     /// Any JSON string
     String,
-    /// Any JSON number
-    #[deprecated(since = "0.1.2", note = "Use sized numeric types instead")]
-    Number,
-    /// Any JSON number, with no decimal part
-    #[deprecated(since = "0.1.2", note = "Use sized numeric types instead")]
-    Integer,
     /// A 8-bit signed integer with a minimum value of -2^7 and a maximum value of 2^7 - 1
     Int8,
     /// A 16-bit signed integer with a minimum value of -2^15 and a maximum value of 2^15 - 1

--- a/ndc-models/tests/json_schema/schema_response.jsonschema
+++ b/ndc-models/tests/json_schema/schema_response.jsonschema
@@ -64,17 +64,15 @@
       "type": "object",
       "required": [
         "aggregate_functions",
-        "comparison_operators"
+        "comparison_operators",
+        "representation"
       ],
       "properties": {
         "representation": {
-          "description": "A description of valid values for this scalar type. Defaults to `TypeRepresentation::JSON` if omitted",
-          "anyOf": [
+          "description": "A description of valid values for this scalar type.",
+          "allOf": [
             {
               "$ref": "#/definitions/TypeRepresentation"
-            },
-            {
-              "type": "null"
             }
           ]
         },
@@ -124,38 +122,6 @@
               "type": "string",
               "enum": [
                 "string"
-              ]
-            }
-          }
-        },
-        {
-          "description": "Any JSON number",
-          "deprecated": true,
-          "type": "object",
-          "required": [
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "number"
-              ]
-            }
-          }
-        },
-        {
-          "description": "Any JSON number, with no decimal part",
-          "deprecated": true,
-          "type": "object",
-          "required": [
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "integer"
               ]
             }
           }

--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -334,7 +334,7 @@ async fn get_schema() -> Json<models::SchemaResponse> {
         (
             "String".into(),
             models::ScalarType {
-                representation: Some(models::TypeRepresentation::String),
+                representation: models::TypeRepresentation::String,
                 aggregate_functions: BTreeMap::new(),
                 comparison_operators: BTreeMap::from_iter([
                     ("eq".into(), models::ComparisonOperatorDefinition::Equal),
@@ -353,7 +353,7 @@ async fn get_schema() -> Json<models::SchemaResponse> {
         (
             "Int".into(),
             models::ScalarType {
-                representation: Some(models::TypeRepresentation::Int32),
+                representation: models::TypeRepresentation::Int32,
                 aggregate_functions: BTreeMap::from_iter([
                     (
                         "max".into(),

--- a/ndc-test/src/test_cases/query/validate/mod.rs
+++ b/ndc-test/src/test_cases/query/validate/mod.rs
@@ -522,15 +522,11 @@ pub fn check_value_has_type(
                     ))
                 }
             } else if let Some(scalar_type) = schema.scalar_types.get(name) {
-                if let Some(representation) = &scalar_type.representation {
-                    representations::check_value_has_representation(
-                        representation,
-                        &value,
-                        json_path,
-                    )
-                } else {
-                    Ok(())
-                }
+                representations::check_value_has_representation(
+                    &scalar_type.representation,
+                    &value,
+                    json_path,
+                )
             } else {
                 Err(Error::NamedTypeIsNotDefined(name.clone()))
             }
@@ -593,11 +589,10 @@ mod representations {
 
         match representation {
             models::TypeRepresentation::Boolean => check!(value.is_boolean(), "boolean"),
-            models::TypeRepresentation::Number
-            | models::TypeRepresentation::Float32
-            | models::TypeRepresentation::Float64 => check!(value.is_number(), "number"),
-            models::TypeRepresentation::Integer
-            | models::TypeRepresentation::Int8
+            models::TypeRepresentation::Float32 | models::TypeRepresentation::Float64 => {
+                check!(value.is_number(), "number");
+            }
+            models::TypeRepresentation::Int8
             | models::TypeRepresentation::Int16
             | models::TypeRepresentation::Int32 => check!(value.is_i64(), "integer"),
             models::TypeRepresentation::String

--- a/specification/src/specification/changelog.md
+++ b/specification/src/specification/changelog.md
@@ -51,6 +51,10 @@ However, field arguments are still considered an unstable feature and their use 
 
 Clients can now [indicate the intended protocol version](./versioning.md#requirements) in a HTTP header alongside any request.
 
+### Scalar type representations
+
+Scalar type representations are now required; previously they were optional, where a missing representation was assumed to mean JSON. In addition, the deprecated number and integer representations have been removed; a more precise representation (such as float64 or int32) should be chosen instead.
+
 ## `0.1.6`
 
 ### Specification

--- a/specification/src/specification/schema/scalar-types.md
+++ b/specification/src/specification/schema/scalar-types.md
@@ -6,9 +6,7 @@ Scalar types define several types of operations, which extend the capabilities o
 
 ## Type Representations
 
-A scalar type definition can include an optional _type representation_. The representation, if provided, indicates to potential callers what values can be expected in responses, and what values are considered acceptable in requests.
-
-If the representation is omitted, it defaults to `json`.
+A scalar type definition must include a _type representation_. The representation indicates to potential callers what values can be expected in responses, and what values are considered acceptable in requests.
 
 ### Supported Representations
 
@@ -45,17 +43,6 @@ For example, this representation indicates that the only three valid values are 
   "one_of": ["foo", "bar", "baz"]
 }
 ```
-
-### Deprecated Representations
-
-The following representations are deprecated as of version 0.1.2:
-
-| `type`    | Description                          | JSON representation |
-| --------- | ------------------------------------ | ------------------- |
-| `number`  | Any JSON number                      | Number              |
-| `integer` | Any JSON number with no decimal part | Number              |
-
-Connectors should use the sized integer and floating-point types instead.
 
 ## Comparison Operators
 


### PR DESCRIPTION
This PR makes type representations in scalar types required. They were previously optional for backwards compatibility, where a missing value was assumed to mean JSON. 

Also the deprecated number and integer representations have been removed.

- [ ] RFC
- [x] Specification updates
  - [x] Changelog
  - [x] Specification pages
  - [x] Tutorial pages
  - [x] `reference/types.md`
- [x] Implement your feature in the reference connector
- [ ] Generate test cases in `ndc-test` if appropriate
- [ ] Does your feature add a new capability?
  - [ ] Update `specification/capabilities.md` in the specification
  - [ ] Check the capability in `ndc-test`
