### PR TITLE
Update changelog with missing breaking changes and add a per-page table of contents to the specification

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,7 @@
 
           pkgs.just
           pkgs.mdbook
+          pkgs.mdbook-pagetoc
           pkgs.nodePackages.prettier
         ] ++ buildDependencies;
 

--- a/specification/README.md
+++ b/specification/README.md
@@ -1,3 +1,3 @@
 # NDC Specification
 
-This directory contains source materials for the NDC specification. The specification can be built using `mdbook`, or [read online](http://hasura.github.io/ndc-spec).
+This directory contains source materials for the NDC specification. The specification can be built using `mdbook`, or [read online](http://hasura.github.io/ndc-spec). If building with `mdbook`, you will also need to install [`mdbook-pagetoc`](https://crates.io/crates/mdbook-pagetoc).

--- a/specification/book.toml
+++ b/specification/book.toml
@@ -4,3 +4,8 @@ language = "en"
 multilingual = false
 src = "src"
 title = "Hasura Data Connectors Developer's Guide"
+
+[preprocessor.pagetoc]
+[output.html]
+additional-css = ["theme/pagetoc.css"]
+additional-js  = ["theme/pagetoc.js"]

--- a/specification/src/specification/changelog.md
+++ b/specification/src/specification/changelog.md
@@ -7,10 +7,12 @@
 - `ComparisonTarget::RootCollectionColumn` was removed and replaced by _named scopes_ ([RFC](https://github.com/hasura/ndc-spec/blob/36855ff20dcbd7d129427794aee9746b895390af/rfcs/0015-named-scopes.md))
 - `path` was removed from `ComparisonTarget::Column` ([RFC](https://github.com/hasura/ndc-spec/blob/36855ff20dcbd7d129427794aee9746b895390af/rfcs/0011-no-paths-in-comparison-target.md))
 - `AggregateFunctionDefinition` was changed to an `enum`, to support _standardized aggregate functions_ ([RFC](https://github.com/hasura/ndc-spec/blob/a6610169f72cec6792d5e0830c57254e212b37d9/rfcs/0021-comparison-and-aggregate-meanings.md))
+- `ComparisonValue::Column` no longer uses `ComparisonTarget` to pick the column. Instead, the necessary column and pathing details are inlined onto the enum variant. This
 - Declarations of foreign keys has moved from `CollectionInfo` to `ObjectType`. This enables object types nested within a collection's object type to declare foreign keys.
 - The target column in column mappings can now reference an object-nested field. The target column is now a field path (`Vec<FieldName>`) instead of just a field (`FieldName`). Column mappings occur in:
   - `Relationship::column_mapping`
   - `ForeignKeyConstraint::column_mapping`
+- Scalar type representations are now required, and the previously deprecated `number` and `integer` representations have been removed.
 
 ### Specification
 

--- a/specification/theme/pagetoc.css
+++ b/specification/theme/pagetoc.css
@@ -1,0 +1,58 @@
+@media only screen and (max-width: 1439px) {
+  .sidetoc {
+    display: none;
+  }
+}
+
+@media only screen and (min-width: 1440px) {
+  main {
+    position: relative;
+  }
+  .sidetoc {
+    margin-left: auto;
+    margin-right: auto;
+    left: calc(100% + (var(--content-max-width)) / 4 - 140px);
+    position: absolute;
+    font-size: 0.875em;
+  }
+  .pagetoc {
+    position: fixed;
+    width: 250px;
+    height: calc(100vh - var(--menu-bar-height) - 0.67em * 4);
+    overflow: auto;
+  }
+  .pagetoc a {
+    border-left: 1px solid var(--sidebar-bg);
+    color: var(--fg) !important;
+    display: block;
+    padding-bottom: 5px;
+    padding-top: 5px;
+    padding-left: 10px;
+    text-align: left;
+    text-decoration: none;
+  }
+  .pagetoc a:hover,
+  .pagetoc a.active {
+    background: var(--sidebar-bg);
+    color: var(--sidebar-fg) !important;
+  }
+  .pagetoc .active {
+    background: var(--sidebar-bg);
+    color: var(--sidebar-fg);
+  }
+  .pagetoc .pagetoc-H2 {
+    padding-left: 20px;
+  }
+  .pagetoc .pagetoc-H3 {
+    padding-left: 40px;
+  }
+  .pagetoc .pagetoc-H4 {
+    padding-left: 60px;
+  }
+  .pagetoc .pagetoc-H5 {
+    display: none;
+  }
+  .pagetoc .pagetoc-H6 {
+    display: none;
+  }
+}

--- a/specification/theme/pagetoc.js
+++ b/specification/theme/pagetoc.js
@@ -1,0 +1,73 @@
+let scrollTimeout;
+
+const listenActive = () => {
+  const elems = document.querySelector(".pagetoc").children;
+  [...elems].forEach((el) => {
+    el.addEventListener("click", (event) => {
+      clearTimeout(scrollTimeout);
+      [...elems].forEach((el) => el.classList.remove("active"));
+      el.classList.add("active");
+      // Prevent scroll updates for a short period
+      scrollTimeout = setTimeout(() => {
+        scrollTimeout = null;
+      }, 100); // Adjust timing as needed
+    });
+  });
+};
+
+const getPagetoc = () =>
+  document.querySelector(".pagetoc") || autoCreatePagetoc();
+
+const autoCreatePagetoc = () => {
+  const main = document.querySelector("#content > main");
+  const content = Object.assign(document.createElement("div"), {
+    className: "content-wrap",
+  });
+  content.append(...main.childNodes);
+  main.prepend(content);
+  main.insertAdjacentHTML(
+    "afterbegin",
+    '<div class="sidetoc"><nav class="pagetoc"></nav></div>',
+  );
+  return document.querySelector(".pagetoc");
+};
+const updateFunction = () => {
+  if (scrollTimeout) return; // Skip updates if within the cooldown period from a click
+  const headers = [...document.getElementsByClassName("header")];
+  const scrolledY = window.scrollY;
+  let lastHeader = null;
+
+  // Find the last header that is above the current scroll position
+  for (let i = headers.length - 1; i >= 0; i--) {
+    if (scrolledY >= headers[i].offsetTop) {
+      lastHeader = headers[i];
+      break;
+    }
+  }
+
+  const pagetocLinks = [...document.querySelector(".pagetoc").children];
+  pagetocLinks.forEach((link) => link.classList.remove("active"));
+
+  if (lastHeader) {
+    const activeLink = pagetocLinks.find(
+      (link) => lastHeader.href === link.href,
+    );
+    if (activeLink) activeLink.classList.add("active");
+  }
+};
+
+window.addEventListener("load", () => {
+  const pagetoc = getPagetoc();
+  const headers = [...document.getElementsByClassName("header")];
+  headers.forEach((header) => {
+    const link = Object.assign(document.createElement("a"), {
+      textContent: header.text,
+      href: header.href,
+      className: `pagetoc-${header.parentElement.tagName}`,
+    });
+    pagetoc.appendChild(link);
+  });
+  updateFunction();
+  listenActive();
+  window.addEventListener("scroll", updateFunction);
+});


### PR DESCRIPTION
This PR adds some missing breaking changes to the changelog. 

It also adds a per-page table of contents to the specification docs that looks like this:

![image](https://github.com/user-attachments/assets/83294bb5-7f56-44a3-bf64-e6259899b9af)

This is built with the [`mdbook-pagetoc`](https://crates.io/crates/mdbook-pagetoc) preprocessor.