### PR TITLE
Remove unnecessary defaulted path and clarified how versioning works in the docs

### DIFF
--- a/ndc-models/src/expression.rs
+++ b/ndc-models/src/expression.rs
@@ -106,7 +106,6 @@ pub enum ComparisonValue {
     Column {
         /// Any relationships to traverse to reach this column.
         /// Only non-empty if the 'relationships.relation_comparisons' is supported.
-        #[serde(default)]
         path: Vec<PathElement>,
         /// The name of the column
         name: FieldName,

--- a/ndc-models/tests/json_schema/mutation_request.jsonschema
+++ b/ndc-models/tests/json_schema/mutation_request.jsonschema
@@ -286,6 +286,7 @@
           "type": "object",
           "required": [
             "name",
+            "path",
             "type"
           ],
           "properties": {
@@ -297,7 +298,6 @@
             },
             "path": {
               "description": "Any relationships to traverse to reach this column. Only non-empty if the 'relationships.relation_comparisons' is supported.",
-              "default": [],
               "type": "array",
               "items": {
                 "$ref": "#/definitions/PathElement"

--- a/ndc-models/tests/json_schema/query_request.jsonschema
+++ b/ndc-models/tests/json_schema/query_request.jsonschema
@@ -312,6 +312,7 @@
           "type": "object",
           "required": [
             "name",
+            "path",
             "type"
           ],
           "properties": {
@@ -323,7 +324,6 @@
             },
             "path": {
               "description": "Any relationships to traverse to reach this column. Only non-empty if the 'relationships.relation_comparisons' is supported.",
-              "default": [],
               "type": "array",
               "items": {
                 "$ref": "#/definitions/PathElement"

--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -3342,10 +3342,12 @@ mod tests {
 
         insta::glob!(test_dir, "query/**/request.json", |req_path| {
             let path = req_path.parent().unwrap();
-            let req_file = File::open(req_path).unwrap();
-            let request = serde_json::from_reader::<_, models::QueryRequest>(req_file).unwrap();
-
             let test_name = path.file_name().unwrap().to_str().unwrap();
+            let req_file = File::open(req_path).unwrap();
+            let request = serde_json::from_reader::<_, models::QueryRequest>(req_file)
+                .unwrap_or_else(|err| {
+                    panic!("unable to deserialize request in test {test_name}: {err}")
+                });
 
             let response = tokio_test::block_on(async {
                 let state = Arc::new(Mutex::new(crate::init_app_state()));
@@ -3375,8 +3377,12 @@ mod tests {
 
         insta::glob!(test_dir, "mutation/**/request.json", |req_path| {
             let path = req_path.parent().unwrap();
+            let test_name = path.file_name().unwrap().to_str().unwrap();
             let req_file = File::open(req_path).unwrap();
-            let request = serde_json::from_reader::<_, models::MutationRequest>(req_file).unwrap();
+            let request = serde_json::from_reader::<_, models::MutationRequest>(req_file)
+                .unwrap_or_else(|err| {
+                    panic!("unable to deserialize request in test {test_name}: {err}")
+                });
 
             let response = tokio_test::block_on(async {
                 let state = Arc::new(Mutex::new(crate::init_app_state()));

--- a/ndc-reference/tests/query/named_scopes/request.json
+++ b/ndc-reference/tests/query/named_scopes/request.json
@@ -32,6 +32,7 @@
             "operator": "eq",
             "value": {
               "type": "column",
+              "path": [],
               "name": "id",
               "scope": 1
             }

--- a/ndc-reference/tests/query/predicate_with_exists_and_relationship/request.json
+++ b/ndc-reference/tests/query/predicate_with_exists_and_relationship/request.json
@@ -54,6 +54,7 @@
                   "operator": "eq",
                   "value": {
                     "type": "column",
+                    "path": [],
                     "name": "id",
                     "scope": 1
                   }

--- a/specification/src/specification/versioning.md
+++ b/specification/src/specification/versioning.md
@@ -1,13 +1,13 @@
 # Versioning
 
-This specification is versioned using semantic versioning, and a data connector claims compatibility with a [semantic version](https://semver.org) range via its [capabilities](capabilities.md) endpoint.
+This specification is versioned using semantic versioning, and a data connector declares the [semantic version](https://semver.org) of the specification that it implements via its [capabilities](capabilities.md) endpoint.
 
 Non-breaking changes to the specification may be achieved via the addition of new capabilities, which a connector will be assumed not to implement if the corresponding field is not present in its capabilities endpoint.
 
 ## Requirements
 
-The client _may_ send a semantic version string in the `X-Hasura-NDC-Version` HTTP header to any of the HTTP endpoints described by this specification. This header communicates the version of this specification that the client intends to use.
+The client _may_ send a semantic version string in the `X-Hasura-NDC-Version` HTTP header to any of the HTTP endpoints described by this specification. This header communicates the version of this specification that the client intends to use. Typically this should be the minimum non-breaking version of the specification that is supported by the client, so that the widest range of connectors can be used. For example, if a client sends supports sending v0.1.6 requests, then it technically is sending requests that are compatible with v0.1.0 clients because non-breaking additions are gated behind capabilities and would be disabled for older connectors. In this case, the client should send `0.1.0` as its version in the header.
 
-_If_ the client sends this header, the connector should check compatibility with the requested version, and return an appropriate HTTP error code (e.g. `400 Bad Request`) if it is not capable of providing an implementation.
+_If_ the client sends this header, the connector should check compatibility with the requested version, and return an appropriate HTTP error code (e.g. `400 Bad Request`) if it is not capable of providing an implementation. Compatibility is defined as the semver range: `^{requested-version}`. For example, if the client sends `0.2.0`, then the compatible semver range is `^0.2.0`. If the connector implemented spec version `0.1.6`, this would be incompatible, but if it implemented spec version `0.2.1`, this would be compatible.
 
 _Note_: the `/capabilities` endpoint also indicates the implemented specification version for any connector, but it may not be practical for a client to check the capabilities endpoint before issuing a new request, so this provides a way to check compatibility in the course of a normal request.


### PR DESCRIPTION
I removed the defaulting of the `ComparisonValue::Column.path` property. The defaulting is causing issues with the TypeScript SDK implementation of the JSON Schema and in other places we simply just require the caller to send an empty array.

I also updated the documentation about versioning to match the reference connector's implementation.