### PR TITLE
Fix missing FieldName type for group aggregates

### DIFF
--- a/ndc-models/src/aggregation.rs
+++ b/ndc-models/src/aggregation.rs
@@ -49,7 +49,7 @@ pub struct Grouping {
     /// Dimensions along which to partition the data
     pub dimensions: Vec<Dimension>,
     /// Aggregates to compute in each group
-    pub aggregates: IndexMap<String, Aggregate>,
+    pub aggregates: IndexMap<FieldName, Aggregate>,
     /// Optionally specify a predicate to apply after grouping rows.
     /// Only used if the 'query.aggregates.group_by.filter' capability is supported.
     pub predicate: Option<GroupExpression>,

--- a/ndc-models/src/requests.rs
+++ b/ndc-models/src/requests.rs
@@ -151,7 +151,7 @@ pub struct Group {
     /// Values of dimensions which identify this group
     pub dimensions: Vec<serde_json::Value>,
     /// Aggregates computed within this group
-    pub aggregates: IndexMap<String, serde_json::Value>,
+    pub aggregates: IndexMap<FieldName, serde_json::Value>,
 }
 // ANCHOR_END: Group
 

--- a/ndc-reference/bin/reference/main.rs
+++ b/ndc-reference/bin/reference/main.rs
@@ -1334,7 +1334,7 @@ fn eval_groups(
     for chunk in &sorted {
         let dimensions = chunk.dimensions.clone();
 
-        let mut aggregates: IndexMap<String, serde_json::Value> = IndexMap::new();
+        let mut aggregates: IndexMap<models::FieldName, serde_json::Value> = IndexMap::new();
         for (aggregate_name, aggregate) in &grouping.aggregates {
             aggregates.insert(
                 aggregate_name.clone(),


### PR DESCRIPTION
Fixes a couple of places in the types where `String` was used in group aggregates rather than `FieldName`.