### PR TITLE
Clarify how filtering and pagination is applied with respect to aggregates and groupings

### DIFF
--- a/specification/src/specification/queries/filtering.md
+++ b/specification/src/specification/queries/filtering.md
@@ -1,6 +1,6 @@
 # Filtering
 
-A [`Query`](../../reference/types.md#query) can specify a predicate expression which should be used to filter rows in the response.
+A [`Query`](../../reference/types.md#query) can specify a predicate expression which should be used to filter rows considered during [field selection](../field-selection.md) for returning rows. The predicate expression also filters the rows that are [aggregated across](../aggregates.md) and [grouped over](../grouping.md) (ie. it filters the input rows to the aggregation/grouping operation).
 
 A predicate expression can be one of
 

--- a/specification/src/specification/queries/pagination.md
+++ b/specification/src/specification/queries/pagination.md
@@ -2,14 +2,14 @@
 
 The `limit` and `offset` parameters on the [`Query`](../../reference/types.md#query) object control pagination:
 
-- `limit` specifies the maximum number of rows to return from a query in the rows property.
-- `offset`: The index of the first row to return.
+- `limit` specifies the maximum number of rows that are considered during field selection and before aggregates and grouping are applied.
+- `offset`: The index of the first row to consider during field selection and before aggregates and grouping are applied.
 
-Both `limit` and `offset` affect the rows returned, and also the rows considered by aggregations.
+`limit` and `offset` are applied after the [predicate filter from the Query](../filtering.md) is applied and after [sorting from the Query](../sorting.md) is applied, but before [aggregates](../aggregates.md) and [grouping](../grouping.md) are applied. Both `limit` and `offset` affect the rows returned by field selection.
 
 ## Requirements
 
-- If `limit` is specified, the response should contain at most that many rows.
+- If `limit` is specified, the response should contain at most that many rows, and aggregates and grouping should be applied to at most that many rows.
 
 ## See also
 


### PR DESCRIPTION
These spec textual changes clarify that filtering and pagination is applied before computing aggregates and groups.