### PR TITLE
Clarify where the relation_comparisons capability is used

### DIFF
--- a/specification/src/specification/capabilities.md
+++ b/specification/src/specification/capabilities.md
@@ -56,7 +56,7 @@ These fields are set underneath the `capabilities` property on the `Capabilities
 | `relationships.nested`                                 | Whether the data connector supports relationships that can [start from or end with columns in nested objects](queries/relationships.md#column-mappings)                                     |
 | `relationships.nested.array`                           | Whether the data connector supports relationships that can [start from columns inside nested objects inside nested arrays](queries/relationships.md#column-mappings)                        |
 | `relationships.order_by_aggregate`                     | Whether order by clauses can [include aggregates](queries/sorting.md#type-aggregate)                                                                                                        |
-| `relationships.relation_comparisons`                   | Whether comparisons can include columns reachable via [relationships](queries/relationships.md)                                                                                             |
+| `relationships.relation_comparisons`                   | Whether comparisons between two columns can include a [value column](queries/filtering.md#values-in-binary-operators) that is across a [relationship](queries/relationships.md)             |
 
 ## See also
 

--- a/specification/src/specification/queries/filtering.md
+++ b/specification/src/specification/queries/filtering.md
@@ -125,7 +125,7 @@ Binary (including array-valued) operators compare columns to _values_, but there
 
 - Scalar values, as seen in the examples above, compare the column to a specific value,
 - Variable values compare the column to the current value of a [variable](./variables.md),
-- Column values compare the column to _another_ column. The column may be on the same row, or it may be on a related row. Comparing against columns on related rows requires the connector to indicate support via the `relationships.relation_comparison` capability.
+- Column values compare the column to _another_ column. The column may be on the same row, or it may be on a related row. Comparing against columns on related rows requires the connector to indicate support via the `relationships.relation_comparisons` capability.
 
 #### Referencing a column from a collection in scope
 

--- a/specification/theme/css/variables.css
+++ b/specification/theme/css/variables.css
@@ -7,8 +7,9 @@
   --page-padding: 15px;
   --content-max-width: 900px; /* Default value: 750px */
   --menu-bar-height: 50px;
-  --mono-font: "Source Code Pro", Consolas, "Ubuntu Mono", Menlo,
-    "DejaVu Sans Mono", monospace, monospace;
+  --mono-font:
+    "Source Code Pro", Consolas, "Ubuntu Mono", Menlo, "DejaVu Sans Mono",
+    monospace, monospace;
   --code-font-size: 0.875em
     /* please adjust the ace font size accordingly in editor.js */;
 }


### PR DESCRIPTION
This capability has been majorly misunderstood in engine, and so its purpose has been clarified.