### PR TITLE
Add missing Millisecond enum in ExtractionFunctionDefinition type

### DIFF
--- a/ndc-models/src/schema.rs
+++ b/ndc-models/src/schema.rs
@@ -230,6 +230,10 @@ pub enum ExtractionFunctionDefinition {
         /// The result type, which must be a defined scalar type in the schema response.
         result_type: ScalarTypeName,
     },
+    Millisecond {
+        /// The result type, which must be a defined scalar type in the schema response.
+        result_type: ScalarTypeName,
+    },
     Second {
         /// The result type, which must be a defined scalar type in the schema response.
         result_type: ScalarTypeName,

--- a/ndc-models/tests/json_schema/schema_response.jsonschema
+++ b/ndc-models/tests/json_schema/schema_response.jsonschema
@@ -497,6 +497,25 @@
             "type": {
               "type": "string",
               "enum": [
+                "millisecond"
+              ]
+            },
+            "result_type": {
+              "description": "The result type, which must be a defined scalar type in the schema response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "result_type",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
                 "second"
               ]
             },

--- a/ndc-test/src/test_cases/schema.rs
+++ b/ndc-test/src/test_cases/schema.rs
@@ -52,6 +52,7 @@ pub async fn validate_schema<R: Reporter>(
                     }
                     ndc_models::ExtractionFunctionDefinition::Nanosecond { result_type }
                     | ndc_models::ExtractionFunctionDefinition::Microsecond { result_type }
+                    | ndc_models::ExtractionFunctionDefinition::Millisecond { result_type }
                     | ndc_models::ExtractionFunctionDefinition::Second { result_type }
                     | ndc_models::ExtractionFunctionDefinition::Minute { result_type }
                     | ndc_models::ExtractionFunctionDefinition::Hour { result_type }

--- a/rfcs/0027-extraction-functions.md
+++ b/rfcs/0027-extraction-functions.md
@@ -39,6 +39,7 @@ pub struct ExtractionFunctionDefinition {
 pub enum ExtractionFunctionType {
     Nanosecond,
     Microsecond,
+    Millisecond,
     Second,
     Minute,
     Hour,

--- a/specification/src/specification/changelog.md
+++ b/specification/src/specification/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Specification
+
 - A millisecond standard [extraction function](./schema/scalar-types.md#extraction-functions) was added.
 
 ## `0.2.0`

--- a/specification/src/specification/changelog.md
+++ b/specification/src/specification/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Specification
+- A millisecond standard [extraction function](./schema/scalar-types.md#extraction-functions) was added.
+
 ## `0.2.0`
 
 ### Breaking Changes

--- a/specification/src/specification/schema/scalar-types.md
+++ b/specification/src/specification/schema/scalar-types.md
@@ -236,6 +236,7 @@ The following standard extraction functions are supported:
 - `DayOfYear`
 - `Hour`
 - `Microsecond`
+- `Millisecond`
 - `Minute`
 - `Month`
 - `Nanosecond`


### PR DESCRIPTION
Add `Millisecond` enum in the `ExtractionFunctionDefinition` type

<!---
If you are contributing to this repository, the first step is to discuss any planned changes in an RFC.
-->

- [ ] RFC
- [ ] Specification updates
  - [ ] Changelog
  - [ ] Specification pages
  - [ ] Tutorial pages
  - [ ] `reference/types.md`
- [ ] Implement your feature in the reference connector
- [ ] Generate test cases in `ndc-test` if appropriate
- [ ] Does your feature add a new capability?
  - [ ] Update `specification/capabilities.md` in the specification
  - [ ] Check the capability in `ndc-test`
