### PR TITLE
Add `get_field` and `array_element` to relational expression

### DIFF
--- a/ndc-models/src/relational_query/capabilities.rs
+++ b/ndc-models/src/relational_query/capabilities.rs
@@ -145,6 +145,7 @@ pub struct RelationalScalarExpressionCapabilities {
     pub divide: Option<LeafCapability>,
     pub exp: Option<LeafCapability>,
     pub floor: Option<LeafCapability>,
+    pub get_field: Option<LeafCapability>,
     pub greatest: Option<LeafCapability>,
     pub least: Option<LeafCapability>,
     pub left: Option<LeafCapability>,

--- a/ndc-models/src/relational_query/capabilities.rs
+++ b/ndc-models/src/relational_query/capabilities.rs
@@ -131,6 +131,7 @@ pub struct RelationalComparisonExpressionCapabilities {
 pub struct RelationalScalarExpressionCapabilities {
     pub abs: Option<LeafCapability>,
     pub and: Option<LeafCapability>,
+    pub array_element: Option<LeafCapability>,
     pub btrim: Option<LeafCapability>,
     pub ceil: Option<LeafCapability>,
     pub character_length: Option<LeafCapability>,

--- a/ndc-models/src/relational_query/expression.rs
+++ b/ndc-models/src/relational_query/expression.rs
@@ -359,6 +359,18 @@ pub enum RelationalExpression {
         expr: Box<RelationalExpression>,
     },
     /// Only used when in specific contexts where the appropriate capability is supported:
+    /// * During projection: `relational_query.project.expression.scalar.get_field`
+    /// * During filtering: `relational_query.filter.scalar.get_field`
+    /// * During sorting:`relational_query.sort.expression.scalar.get_field`
+    /// * During joining: `relational_query.join.expression.scalar.get_field`
+    /// * During aggregation: `relational_query.aggregate.expression.scalar.get_field`
+    /// * During windowing: `relational_query.window.expression.scalar.get_field`
+    GetField {
+        column: Box<RelationalExpression>,
+        field: Box<RelationalLiteral>,
+    },
+
+    /// Only used when in specific contexts where the appropriate capability is supported:
     /// * During projection: `relational_query.project.expression.scalar.greatest`
     /// * During filtering: `relational_query.filter.scalar.greatest`
     /// * During sorting:`relational_query.sort.expression.scalar.greatest`

--- a/ndc-models/src/relational_query/expression.rs
+++ b/ndc-models/src/relational_query/expression.rs
@@ -367,7 +367,7 @@ pub enum RelationalExpression {
     /// * During windowing: `relational_query.window.expression.scalar.get_field`
     GetField {
         column: Box<RelationalExpression>,
-        field: Box<RelationalLiteral>,
+        field: RelationalLiteral,
     },
 
     /// Only used when in specific contexts where the appropriate capability is supported:

--- a/ndc-models/src/relational_query/expression.rs
+++ b/ndc-models/src/relational_query/expression.rs
@@ -247,7 +247,7 @@ pub enum RelationalExpression {
     /// * During windowing: `relational_query.window.expression.scalar.array_element`
     ArrayElement {
         column: Box<RelationalExpression>,
-        field: usize,
+        index: usize,
     },
     /// Only used when in specific contexts where the appropriate capability is supported:
     /// * During projection: `relational_query.project.expression.scalar.btrim`

--- a/ndc-models/src/relational_query/expression.rs
+++ b/ndc-models/src/relational_query/expression.rs
@@ -367,7 +367,7 @@ pub enum RelationalExpression {
     /// * During windowing: `relational_query.window.expression.scalar.get_field`
     GetField {
         column: Box<RelationalExpression>,
-        field: RelationalLiteral,
+        field: FieldIndex,
     },
 
     /// Only used when in specific contexts where the appropriate capability is supported:
@@ -909,6 +909,12 @@ pub enum RelationalExpression {
     // lag
     // lead
     // nth_value
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize, Deserialize, JsonSchema)]
+pub enum FieldIndex {
+    ByName(String),
+    ByIndex(usize),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize, Deserialize, JsonSchema)]

--- a/ndc-models/src/relational_query/expression.rs
+++ b/ndc-models/src/relational_query/expression.rs
@@ -239,6 +239,17 @@ pub enum RelationalExpression {
         expr: Box<RelationalExpression>,
     },
     /// Only used when in specific contexts where the appropriate capability is supported:
+    /// * During projection: `relational_query.project.expression.scalar.array_element`
+    /// * During filtering: `relational_query.filter.scalar.array_element`
+    /// * During sorting:`relational_query.sort.expression.scalar.array_element`
+    /// * During joining: `relational_query.join.expression.scalar.array_element`
+    /// * During aggregation: `relational_query.aggregate.expression.scalar.array_element`
+    /// * During windowing: `relational_query.window.expression.scalar.array_element`
+    ArrayElement {
+        column: Box<RelationalExpression>,
+        field: usize,
+    },
+    /// Only used when in specific contexts where the appropriate capability is supported:
     /// * During projection: `relational_query.project.expression.scalar.btrim`
     /// * During filtering: `relational_query.filter.scalar.btrim`
     /// * During sorting:`relational_query.sort.expression.scalar.btrim`
@@ -367,7 +378,7 @@ pub enum RelationalExpression {
     /// * During windowing: `relational_query.window.expression.scalar.get_field`
     GetField {
         column: Box<RelationalExpression>,
-        field: FieldIndex,
+        field: String,
     },
 
     /// Only used when in specific contexts where the appropriate capability is supported:
@@ -909,12 +920,6 @@ pub enum RelationalExpression {
     // lag
     // lead
     // nth_value
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize, Deserialize, JsonSchema)]
-pub enum FieldIndex {
-    ByName(String),
-    ByIndex(usize),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize, Deserialize, JsonSchema)]

--- a/ndc-models/tests/json_schema/capabilities_response.jsonschema
+++ b/ndc-models/tests/json_schema/capabilities_response.jsonschema
@@ -1054,6 +1054,16 @@
             }
           ]
         },
+        "array_element": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "btrim": {
           "anyOf": [
             {

--- a/ndc-models/tests/json_schema/capabilities_response.jsonschema
+++ b/ndc-models/tests/json_schema/capabilities_response.jsonschema
@@ -1194,6 +1194,16 @@
             }
           ]
         },
+        "get_field": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "greatest": {
           "anyOf": [
             {

--- a/ndc-models/tests/json_schema/relational_query.jsonschema
+++ b/ndc-models/tests/json_schema/relational_query.jsonschema
@@ -342,36 +342,6 @@
         "nanosecond"
       ]
     },
-    "FieldIndex": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "ByName"
-          ],
-          "properties": {
-            "ByName": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "ByIndex"
-          ],
-          "properties": {
-            "ByIndex": {
-              "type": "integer",
-              "format": "uint",
-              "minimum": 0.0
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
     "JoinOn": {
       "title": "JoinOn",
       "type": "object",
@@ -1486,6 +1456,31 @@
           }
         },
         {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.array_element` * During filtering: `relational_query.filter.scalar.array_element` * During sorting:`relational_query.sort.expression.scalar.array_element` * During joining: `relational_query.join.expression.scalar.array_element` * During aggregation: `relational_query.aggregate.expression.scalar.array_element` * During windowing: `relational_query.window.expression.scalar.array_element`",
+          "type": "object",
+          "required": [
+            "column",
+            "field",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "array_element"
+              ]
+            },
+            "column": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "field": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
           "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.btrim` * During filtering: `relational_query.filter.scalar.btrim` * During sorting:`relational_query.sort.expression.scalar.btrim` * During joining: `relational_query.join.expression.scalar.btrim` * During aggregation: `relational_query.aggregate.expression.scalar.btrim` * During windowing: `relational_query.window.expression.scalar.btrim`",
           "type": "object",
           "required": [
@@ -1762,7 +1757,7 @@
               "$ref": "#/definitions/RelationalExpression"
             },
             "field": {
-              "$ref": "#/definitions/FieldIndex"
+              "type": "string"
             }
           }
         },

--- a/ndc-models/tests/json_schema/relational_query.jsonschema
+++ b/ndc-models/tests/json_schema/relational_query.jsonschema
@@ -1460,7 +1460,7 @@
           "type": "object",
           "required": [
             "column",
-            "field",
+            "index",
             "type"
           ],
           "properties": {
@@ -1473,7 +1473,7 @@
             "column": {
               "$ref": "#/definitions/RelationalExpression"
             },
-            "field": {
+            "index": {
               "type": "integer",
               "format": "uint",
               "minimum": 0.0

--- a/ndc-models/tests/json_schema/relational_query.jsonschema
+++ b/ndc-models/tests/json_schema/relational_query.jsonschema
@@ -1714,6 +1714,29 @@
           }
         },
         {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.get_field` * During filtering: `relational_query.filter.scalar.get_field` * During sorting:`relational_query.sort.expression.scalar.get_field` * During joining: `relational_query.join.expression.scalar.get_field` * During aggregation: `relational_query.aggregate.expression.scalar.get_field` * During windowing: `relational_query.window.expression.scalar.get_field`",
+          "type": "object",
+          "required": [
+            "column",
+            "field",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "get_field"
+              ]
+            },
+            "column": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "field": {
+              "$ref": "#/definitions/RelationalLiteral"
+            }
+          }
+        },
+        {
           "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.greatest` * During filtering: `relational_query.filter.scalar.greatest` * During sorting:`relational_query.sort.expression.scalar.greatest` * During joining: `relational_query.join.expression.scalar.greatest` * During aggregation: `relational_query.aggregate.expression.scalar.greatest` * During windowing: `relational_query.window.expression.scalar.greatest`",
           "type": "object",
           "required": [

--- a/ndc-models/tests/json_schema/relational_query.jsonschema
+++ b/ndc-models/tests/json_schema/relational_query.jsonschema
@@ -342,6 +342,36 @@
         "nanosecond"
       ]
     },
+    "FieldIndex": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "ByName"
+          ],
+          "properties": {
+            "ByName": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ByIndex"
+          ],
+          "properties": {
+            "ByIndex": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "JoinOn": {
       "title": "JoinOn",
       "type": "object",
@@ -1732,7 +1762,7 @@
               "$ref": "#/definitions/RelationalExpression"
             },
             "field": {
-              "$ref": "#/definitions/RelationalLiteral"
+              "$ref": "#/definitions/FieldIndex"
             }
           }
         },


### PR DESCRIPTION
Allow accessing nested fields and array elements.

<!---
If you are contributing to this repository, the first step is to discuss any planned changes in an RFC.
-->

- [ ] RFC
- [ ] Specification updates
  - [ ] Changelog
  - [ ] Specification pages
  - [ ] Tutorial pages
  - [ ] `reference/types.md`
- [ ] Implement your feature in the reference connector
- [ ] Generate test cases in `ndc-test` if appropriate
- [X] Does your feature add a new capability?
  - [X] Update `specification/capabilities.md` in the specification
  - [ ] Check the capability in `ndc-test`
