### PR TITLE
Add `arguments` to `From`

### DIFF
--- a/ndc-models/src/relational_query/capabilities.rs
+++ b/ndc-models/src/relational_query/capabilities.rs
@@ -13,12 +13,22 @@ use crate::LeafCapability;
 pub struct RelationalQueryCapabilities {
     pub project: RelationalProjectionCapabilities,
     pub filter: Option<RelationalExpressionCapabilities>,
+    pub from: Option<RelationalFromCapabilities>,
     pub sort: Option<RelationalSortCapabilities>,
     pub join: Option<RelationalJoinCapabilities>,
     pub aggregate: Option<RelationalAggregateCapabilities>,
     pub window: Option<RelationalWindowCapabilities>,
 }
 // ANCHOR_END: RelationalQueryCapabilities
+
+// ANCHOR: RelationalFromCapabilities
+#[skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[schemars(title = "Relational From Capabilities")]
+pub struct RelationalFromCapabilities {
+    pub arguments: Option<LeafCapability>,
+}
+// ANCHOR_END: RelationalFromCapabilities
 
 // ANCHOR: RelationalProjectionCapabilities
 #[skip_serializing_none]

--- a/ndc-models/src/relational_query/mod.rs
+++ b/ndc-models/src/relational_query/mod.rs
@@ -9,7 +9,7 @@ pub use expression::*;
 mod types;
 pub use types::*;
 
-use crate::{CollectionName, FieldName, OrderDirection};
+use crate::{ArgumentName, CollectionName, FieldName, OrderDirection};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -33,6 +33,9 @@ pub enum Relation {
     From {
         collection: CollectionName,
         columns: Vec<FieldName>,
+
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        arguments: Vec<(ArgumentName, RelationalExpression)>,
     },
     Paginate {
         #[cfg(not(feature = "arc-relation"))]

--- a/ndc-models/src/relational_query/mod.rs
+++ b/ndc-models/src/relational_query/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -34,8 +36,8 @@ pub enum Relation {
         collection: CollectionName,
         columns: Vec<FieldName>,
 
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        arguments: Vec<(ArgumentName, RelationalLiteral)>,
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        arguments: BTreeMap<ArgumentName, RelationalLiteral>,
     },
     Paginate {
         #[cfg(not(feature = "arc-relation"))]

--- a/ndc-models/src/relational_query/mod.rs
+++ b/ndc-models/src/relational_query/mod.rs
@@ -35,7 +35,7 @@ pub enum Relation {
         columns: Vec<FieldName>,
 
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        arguments: Vec<(ArgumentName, RelationalExpression)>,
+        arguments: Vec<(ArgumentName, RelationalLiteral)>,
     },
     Paginate {
         #[cfg(not(feature = "arc-relation"))]

--- a/ndc-models/tests/json_schema/capabilities_response.jsonschema
+++ b/ndc-models/tests/json_schema/capabilities_response.jsonschema
@@ -893,6 +893,22 @@
         }
       }
     },
+    "RelationalFromCapabilities": {
+      "title": "Relational From Capabilities",
+      "type": "object",
+      "properties": {
+        "arguments": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
     "RelationalJoinCapabilities": {
       "title": "Relational Join Capabilities",
       "type": "object",
@@ -1022,6 +1038,16 @@
           "anyOf": [
             {
               "$ref": "#/definitions/RelationalExpressionCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "from": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RelationalFromCapabilities"
             },
             {
               "type": "null"

--- a/ndc-models/tests/json_schema/relational_query.jsonschema
+++ b/ndc-models/tests/json_schema/relational_query.jsonschema
@@ -470,7 +470,7 @@
                     "type": "string"
                   },
                   {
-                    "$ref": "#/definitions/RelationalExpression"
+                    "$ref": "#/definitions/RelationalLiteral"
                   }
                 ],
                 "maxItems": 2,

--- a/ndc-models/tests/json_schema/relational_query.jsonschema
+++ b/ndc-models/tests/json_schema/relational_query.jsonschema
@@ -460,6 +460,22 @@
               "items": {
                 "type": "string"
               }
+            },
+            "arguments": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/RelationalExpression"
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
             }
           }
         },

--- a/ndc-models/tests/json_schema/relational_query.jsonschema
+++ b/ndc-models/tests/json_schema/relational_query.jsonschema
@@ -462,19 +462,9 @@
               }
             },
             "arguments": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "items": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/definitions/RelationalLiteral"
-                  }
-                ],
-                "maxItems": 2,
-                "minItems": 2
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/RelationalLiteral"
               }
             }
           }


### PR DESCRIPTION
<!---
If you are contributing to this repository, the first step is to discuss any planned changes in an RFC.
-->

This adds `arguments` to the `From` constructor in relational queries. This allows model arguments to be included with a query.

- [ ] RFC
- [ ] Specification updates
  - [ ] Changelog
  - [ ] Specification pages
  - [ ] Tutorial pages
  - [ ] `reference/types.md`
- [ ] Implement your feature in the reference connector
- [ ] Generate test cases in `ndc-test` if appropriate
- [ ] Does your feature add a new capability?
  - [ ] Update `specification/capabilities.md` in the specification
  - [ ] Check the capability in `ndc-test`
