### PR TITLE
[PQL-503] New binary string concatenation operator

### DIFF
--- a/ndc-models/src/relational_query/capabilities.rs
+++ b/ndc-models/src/relational_query/capabilities.rs
@@ -136,6 +136,7 @@ pub struct RelationalScalarExpressionCapabilities {
     pub abs: Option<LeafCapability>,
     pub and: Option<LeafCapability>,
     pub array_element: Option<LeafCapability>,
+    pub binary_concat: Option<LeafCapability>,
     pub btrim: Option<LeafCapability>,
     pub ceil: Option<LeafCapability>,
     pub character_length: Option<LeafCapability>,

--- a/ndc-models/src/relational_query/expression.rs
+++ b/ndc-models/src/relational_query/expression.rs
@@ -683,6 +683,17 @@ pub enum RelationalExpression {
     ToUpper {
         expr: Box<RelationalExpression>,
     },
+    /// Only used when in specific contexts where the appropriate capability is supported:
+    /// * During projection: `relational_query.project.expression.scalar.binary_concat`
+    /// * During filtering: `relational_query.filter.scalar.binary_concat`
+    /// * During sorting:`relational_query.sort.expression.scalar.binary_concat`
+    /// * During joining: `relational_query.join.expression.scalar.binary_concat`
+    /// * During aggregation: `relational_query.aggregate.expression.scalar.binary_concat`
+    /// * During windowing: `relational_query.window.expression.scalar.binary_concat`
+    BinaryConcat {
+        left: Box<RelationalExpression>,
+        right: Box<RelationalExpression>,
+    },
 
     // acos
     // acosh

--- a/ndc-models/tests/json_schema/capabilities_response.jsonschema
+++ b/ndc-models/tests/json_schema/capabilities_response.jsonschema
@@ -1104,6 +1104,16 @@
             }
           ]
         },
+        "binary_concat": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "btrim": {
           "anyOf": [
             {

--- a/ndc-models/tests/json_schema/relational_query.jsonschema
+++ b/ndc-models/tests/json_schema/relational_query.jsonschema
@@ -2480,6 +2480,29 @@
           }
         },
         {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.binary_concat` * During filtering: `relational_query.filter.scalar.binary_concat` * During sorting:`relational_query.sort.expression.scalar.binary_concat` * During joining: `relational_query.join.expression.scalar.binary_concat` * During aggregation: `relational_query.aggregate.expression.scalar.binary_concat` * During windowing: `relational_query.window.expression.scalar.binary_concat`",
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "binary_concat"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
           "type": "object",
           "required": [
             "expr",


### PR DESCRIPTION
Can't use n-ary `CONCAT` because it treats `NULL` differently.

- [ ] RFC
- [ ] Specification updates
  - [ ] Changelog
  - [ ] Specification pages
  - [ ] Tutorial pages
  - [ ] `reference/types.md`
- [ ] Implement your feature in the reference connector
- [ ] Generate test cases in `ndc-test` if appropriate
- [x] Does your feature add a new capability?
  - [ ] Update `specification/capabilities.md` in the specification
  - [ ] Check the capability in `ndc-test`
