### PR TITLE
Lift compulsory null argument values restriction

### DIFF
--- a/rfcs/0028-request-level-arguments.md
+++ b/rfcs/0028-request-level-arguments.md
@@ -29,7 +29,7 @@ pub struct RequestLevelArguments {
 }
 ```
 
-`ArgumentInfo` is the same type used for other argument definitions \- it includes a type and optional description. As with other arguments, a nullable argument should always be passed with `null` rather than omitted, we prefer to make the user be explicit to ensure a misconfigured plugin (that doesn’t add an argument) doesn’t accidentally change the DB a user accesses.
+`ArgumentInfo` is the same type used for other argument definitions \- it includes a type and optional description. If a nullable argument is not supplied, we shall assume a `null` value has been passed for that argument.
 
 The following fields are added to the `QueryRequest`, `MutationRequest` and `RelationalQuery` types:
 


### PR DESCRIPTION
<!---
If you are contributing to this repository, the first step is to discuss any planned changes in an RFC.
-->

This change is make missing request-level arguments be treated as if `null` was passed. This is so an older engine with no request level arguments support can be supported by a connector (so long as all it's arguments are nullable).

- [ ] RFC
- [X] Specification updates
  - [ ] Changelog
  - [X] Specification pages
  - [ ] Tutorial pages
  - [ ] `reference/types.md`
- [ ] Implement your feature in the reference connector
- [ ] Generate test cases in `ndc-test` if appropriate
- [ ] Does your feature add a new capability?
  - [ ] Update `specification/capabilities.md` in the specification
  - [ ] Check the capability in `ndc-test`
