### PR TITLE
Fix request_arguments not actually skipping serializing none

### DIFF
--- a/ndc-models/src/relational_query/mod.rs
+++ b/ndc-models/src/relational_query/mod.rs
@@ -13,10 +13,10 @@ pub use types::*;
 
 use crate::{ArgumentName, CollectionName, FieldName, OrderDirection};
 
+#[skip_serializing_none]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[schemars(title = "RelationalQuery")]
-#[skip_serializing_none]
 pub struct RelationalQuery {
     pub root_relation: Relation,
     /// Values to be provided to request-level arguments.

--- a/ndc-models/src/requests.rs
+++ b/ndc-models/src/requests.rs
@@ -188,9 +188,9 @@ pub struct ExplainResponse {
 // ANCHOR_END: ExplainResponse
 
 // ANCHOR: MutationRequest
+#[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[schemars(title = "Mutation Request")]
-#[skip_serializing_none]
 pub struct MutationRequest {
     /// The mutation operations to perform
     pub operations: Vec<MutationOperation>,


### PR DESCRIPTION
The macro attribute needs to be put above the serde derive or it doesn't work.