### PR TITLE
Add explicit capability for `from_type` in Cast

### DIFF
--- a/ndc-models/src/relational_query/capabilities.rs
+++ b/ndc-models/src/relational_query/capabilities.rs
@@ -262,7 +262,7 @@ pub struct RelationalAggregateFunctionCapabilities {
 // ANCHOR: RelationalCastCapabilities
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
-#[schemars(title = "Relational Aggregate Function Capabilities")]
+#[schemars(title = "Relational Cast Capabilities")]
 pub struct RelationalCastCapabilities {
     pub from_type: Option<LeafCapability>,
 }

--- a/ndc-models/tests/json_schema/capabilities_response.jsonschema
+++ b/ndc-models/tests/json_schema/capabilities_response.jsonschema
@@ -781,7 +781,7 @@
       }
     },
     "RelationalCastCapabilities": {
-      "title": "Relational Aggregate Function Capabilities",
+      "title": "Relational Cast Capabilities",
       "type": "object",
       "properties": {
         "from_type": {


### PR DESCRIPTION
<!---
If you are contributing to this repository, the first step is to discuss any planned changes in an RFC.
-->

Allow connectors to announce they support this, otherwise engine may send it to connectors that don't understand it resulting in JSON decode errors.

- [ ] RFC
- [ ] Specification updates
  - [ ] Changelog
  - [ ] Specification pages
  - [ ] Tutorial pages
  - [ ] `reference/types.md`
- [ ] Implement your feature in the reference connector
- [ ] Generate test cases in `ndc-test` if appropriate
- [ ] Does your feature add a new capability?
  - [ ] Update `specification/capabilities.md` in the specification
  - [ ] Check the capability in `ndc-test`
