### PR TITLE
Move `from_type` capability into RelationalScalarTypeCapabilities

### DIFF
--- a/ndc-models/src/relational_query/capabilities.rs
+++ b/ndc-models/src/relational_query/capabilities.rs
@@ -89,7 +89,6 @@ pub struct RelationalWindowCapabilities {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[schemars(title = "Relational Expression Capabilities")]
 pub struct RelationalExpressionCapabilities {
-    pub cast: Option<RelationalCastCapabilities>,
     pub conditional: RelationalConditionalExpressionCapabilities,
     pub comparison: RelationalComparisonExpressionCapabilities,
     pub scalar: RelationalScalarExpressionCapabilities,
@@ -259,15 +258,6 @@ pub struct RelationalAggregateFunctionCapabilities {
 }
 // ANCHOR_END: RelationalAggregateFunctionCapabilities
 
-// ANCHOR: RelationalCastCapabilities
-#[skip_serializing_none]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
-#[schemars(title = "Relational Cast Capabilities")]
-pub struct RelationalCastCapabilities {
-    pub from_type: Option<LeafCapability>,
-}
-// ANCHOR_END: RelationalCastCapabilities
-
 // ANCHOR: RelationalOrderedAggregateFunctionCapabilities
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -300,5 +290,7 @@ pub struct RelationalScalarTypeCapabilities {
     /// Does the connector support the INTERVAL scalar type?
     /// Both interval literals and casts to the INTERVAL type are implied by this capability.
     pub interval: Option<LeafCapability>,
+    /// Does the connector support `from_type` in cast?
+    pub from_type: Option<LeafCapability>,
 }
 // ANCHOR_END: RelationalScalarTypeCapabilities

--- a/ndc-models/tests/json_schema/capabilities_response.jsonschema
+++ b/ndc-models/tests/json_schema/capabilities_response.jsonschema
@@ -780,22 +780,6 @@
         }
       }
     },
-    "RelationalCastCapabilities": {
-      "title": "Relational Cast Capabilities",
-      "type": "object",
-      "properties": {
-        "from_type": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/LeafCapability"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
     "RelationalComparisonExpressionCapabilities": {
       "title": "Relational Filter Expression Capabilities",
       "type": "object",
@@ -989,16 +973,6 @@
         "window"
       ],
       "properties": {
-        "cast": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/RelationalCastCapabilities"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "conditional": {
           "$ref": "#/definitions/RelationalConditionalExpressionCapabilities"
         },
@@ -1828,6 +1802,17 @@
       "properties": {
         "interval": {
           "description": "Does the connector support the INTERVAL scalar type? Both interval literals and casts to the INTERVAL type are implied by this capability.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "from_type": {
+          "description": "Does the connector support `from_type` in cast?",
           "anyOf": [
             {
               "$ref": "#/definitions/LeafCapability"


### PR DESCRIPTION
<!---
If you are contributing to this repository, the first step is to discuss any planned changes in an RFC.
-->

- [ ] RFC
- [ ] Specification updates
  - [ ] Changelog
  - [ ] Specification pages
  - [ ] Tutorial pages
  - [ ] `reference/types.md`
- [ ] Implement your feature in the reference connector
- [ ] Generate test cases in `ndc-test` if appropriate
- [ ] Does your feature add a new capability?
  - [ ] Update `specification/capabilities.md` in the specification
  - [ ] Check the capability in `ndc-test`
