### PR TITLE
Add new string_agg_with_separator capability

### DIFF
--- a/ndc-models/src/relational_query/capabilities.rs
+++ b/ndc-models/src/relational_query/capabilities.rs
@@ -238,7 +238,10 @@ pub struct RelationalAggregateExpressionCapabilities {
     pub max: Option<LeafCapability>,
     pub median: Option<LeafCapability>,
     pub min: Option<LeafCapability>,
+    // Note: this capability is essentially ignored in favour of `string_agg_with_separator`
     pub string_agg: Option<RelationalOrderedAggregateFunctionCapabilities>,
+    // This capability replaces `string_agg`
+    pub string_agg_with_separator: Option<RelationalOrderedAggregateFunctionCapabilities>,
     pub sum: Option<LeafCapability>,
     pub var: Option<LeafCapability>,
     pub stddev: Option<LeafCapability>,

--- a/ndc-models/tests/json_schema/capabilities_response.jsonschema
+++ b/ndc-models/tests/json_schema/capabilities_response.jsonschema
@@ -676,6 +676,16 @@
             }
           ]
         },
+        "string_agg_with_separator": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RelationalOrderedAggregateFunctionCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "sum": {
           "anyOf": [
             {


### PR DESCRIPTION
<!---
If you are contributing to this repository, the first step is to discuss any planned changes in an RFC.
-->

The `separator` field added to `StringAgg` in relational queries was a breaking change, so this adds a new capability that must be enabled before we send `StringAgg` in future, so that an implementing connector is able to signal it has fixed the issue.

- [ ] RFC
- [ ] Specification updates
  - [ ] Changelog
  - [ ] Specification pages
  - [ ] Tutorial pages
  - [ ] `reference/types.md`
- [ ] Implement your feature in the reference connector
- [ ] Generate test cases in `ndc-test` if appropriate
- [ ] Does your feature add a new capability?
  - [ ] Update `specification/capabilities.md` in the specification
  - [ ] Check the capability in `ndc-test`
