### PR TITLE
chore(images): migrate base images to private -stable aliases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,6 @@ RUN cargo build --release --all-targets
 
 ###
 # Ship the app in an image with very little else
-FROM debian:bookworm-slim as ndc-reference
+FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/debian:bookworm-slim-stable as ndc-reference
 COPY --from=build /app/target/release/ndc-reference /usr/bin/ndc-reference
 ENTRYPOINT ["ndc-reference"]


### PR DESCRIPTION
## Summary

Re-homes base images in this repo to Hasura's private Artifact Registry `us-docker.pkg.dev/hasura-container-images/external-images` via floating `-stable` aliases. These aliases auto-advance to the latest patched digest of the same version line, so no version bumps are introduced — only the registry/source of the image changes.

Per Hasura policy, every container deployed in Hasura infra must be pulled from the private registry rather than upstream registries (Docker Hub, ghcr.io, gcr.io, quay.io, etc.). Upstream base images are vendored there using a `preserve-source` path layout.

## Exact FROM swaps

### `Dockerfile`
- `FROM debian:bookworm-slim` → `FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/debian:bookworm-slim-stable`
  (the `as ndc-reference` stage suffix is preserved)

## Notes

This is part of an org-wide **Phase 1** migration: exact-match swaps only — same tag/version line, no reformatting, no other changes.