### PR TITLE
feat(ndc-models): add disjunct_streaming_error relational query capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-models"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "goldenfile",
  "indexmap 2.6.0",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-reference"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "async-trait",
  "axum",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-test"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-package.version = "0.2.13"
+package.version = "0.2.14"
 package.edition = "2021"
 
 members = ["ndc-models", "ndc-reference", "ndc-test"]

--- a/ndc-models/src/relational_query/capabilities.rs
+++ b/ndc-models/src/relational_query/capabilities.rs
@@ -19,6 +19,13 @@ pub struct RelationalQueryCapabilities {
     pub window: Option<RelationalWindowCapabilities>,
     pub union: Option<LeafCapability>,
     pub streaming: Option<LeafCapability>,
+    /// Does the connector emit a disjoint, tagged JSON-object error frame on the
+    /// relational streaming response instead of the ambiguous legacy
+    /// `[status, message]` JSON array? When present, consumers can parse the
+    /// stream without the row-first heuristic, so rows such as `[171, "Ben Harper"]`
+    /// are never misinterpreted as errors. This feature is experimental and
+    /// subject to breaking changes within minor versions.
+    pub disjunct_streaming_error: Option<LeafCapability>,
 }
 // ANCHOR_END: RelationalQueryCapabilities
 

--- a/ndc-models/tests/json_schema/capabilities_response.jsonschema
+++ b/ndc-models/tests/json_schema/capabilities_response.jsonschema
@@ -1267,6 +1267,17 @@
               "type": "null"
             }
           ]
+        },
+        "disjunct_streaming_error": {
+          "description": "Does the connector emit a disjoint, tagged JSON-object error frame on the relational streaming response instead of the ambiguous legacy `[status, message]` JSON array? When present, consumers can parse the stream without the row-first heuristic, so rows such as `[171, \"Ben Harper\"]` are never misinterpreted as errors. This feature is experimental and subject to breaking changes within minor versions.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },


### PR DESCRIPTION
Adds the canonical Rust `ndc-models` `disjunct_streaming_error` relational query capability (optional `LeafCapability`), regenerates the `capabilities_response` JSON-schema goldenfile, and bumps the crate to 0.2.14. Backward compatible (optional field).

## Multi-repo stack: `disjunct_streaming_error`

The relational streaming response is NDJSON where each row is a JSON **array**.
Legacy connectors signalled errors with another JSON array `[status, message]`,
so v3-engine (which tried to parse *every* line as `(u16, String)` first)
misinterpreted a valid row such as `[171, "Ben Harper"]` as an HTTP 171 error.

This stack adds an opt-in NDC capability `disjunct_streaming_error`. Capable
connectors emit a disjoint, tagged JSON-**object** frame
`{"type":"error","status","message","details"}` — structurally disjoint from row
arrays — and v3-engine selects the new object-frame parser **only** for
connectors that advertise it, retaining the legacy `[status, message]` parser for
everyone else (no global row-first heuristic).

### Repositories / branches / merge-deploy order

| Order | Repo | Branch | PR | Change |
|------:|------|--------|----|--------|
| 1 | hasura/ndc-spec | `djh/disjunct-streaming-error-models` | this stack | canonical Rust `ndc-models` capability field + schema + version |
| 2 | hasura/v3-engine | `djh/disjunct-streaming-error-engine` | this stack | capability storage/mapping, gated parser, tests, custom-connector |
| 3 | hasura/ndc-sdk-kotlin | `djh/disjunct-streaming-error-sdk-kotlin` | this stack | Kotlin capability field + disjoint stream writer + tests (publish 2.3.0) |
| 4 | hasura/ndc-jdbc | `djh/disjunct-streaming-error-jdbc` | this stack | advertise capability + bump SDK to 2.3.0 |
| 5 | hasura/ndc-sdk-rs | `djh/disjunct-streaming-error-sdk-rs` | this stack | emit disjoint frame + tests |

**Merge/deploy order:** models → engine → Kotlin SDK → JDBC → Rust SDK. The
engine is backward compatible and should ship before connectors advertise the
capability. A connector must never advertise the capability before it emits the
new frame.

### Dependency / release prerequisites
- **ndc-spec:** cut a release/tag containing `disjunct_streaming_error`. The Rust
  downstreams currently use a **development git pin** (ndc-spec v0.2.12 **plus
  only** this field, on branch `djh/disjunct-streaming-error-models-v0_2_12-devpin`)
  so their diffs stay minimal; repoint to the real tag post-merge (see the
  `Cargo.toml` TODO in each).
- **ndc-sdk-kotlin 2.3.0** must be published to
  `maven.pkg.github.com/hasura/ndc-sdk-kotlin` before the JDBC PR's CI can resolve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
